### PR TITLE
Release 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,21 @@ of a number, methods for checking and validating if a number is less than or gre
 number falls in a given range.
 
 ## Get Started
+There are different ways you can use the library:-
 
-To use the library, make sure you have jcenter in your repositories closure:
+### Maven
+Add the following dependency to your `pom` file.
+```xml
+<dependency>
+    <groupId>com.kori_47</groupId>
+    <artifactId>utils</artifactId>
+    <version>1.2.0</version>
+    <type>pom</type>
+</dependency>
+```
+
+### Gradle
+Make sure you have jcenter in your repositories closure.
 
 ```gradle
 repositories {
@@ -31,14 +44,22 @@ repositories {
 }
 ```
 
-Then add the following dependency to your `build.gradle`:
+Then add the following dependency to your `build.gradle`.
 
 ```gradle
 dependencies {
-    api 'com.kori_47:utils:1.1.0'
+    api 'com.kori_47:utils:1.2.0'
 }
 ```
 
+### Ivy
+```xml
+<dependency org='com.kori_47' name='utils' rev='1.2.0'>
+    <artifact name='utils' ext='pom' ></artifactId>
+</dependency>
+```
+
+### Building the library
 Or alternatively, you can use [gradle](https://gradle.org/) to compile and build the library. Just follow the steps bellow:
 
 * Clone the project from [github](https://github.com/kennedykori/JavaUtils).

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 group = 'com.kori_47'
-version = '1.1.0'
+version = '1.2.0'
 
 repositories {
     // Use jcenter for resolving dependencies.
@@ -78,7 +78,6 @@ def pomConfig = {
             email 'kennedykori47@gmail.com'
         }
     }
-    
     scm {
        url 'https://github.com/kennedykori/JavaUtils'
     }
@@ -91,11 +90,11 @@ publishing {
             // Attach sources and javadoc Jars to the main maven publication
             artifact sourcesJar
             artifact javadocJar
-            
+
             groupId 'com.kori_47'
             artifactId 'utils'
-            version '1.1.0'
-            
+            version '1.2.0'
+
             pom.withXml {
                 def root = asNode()
                 root.appendNode('description', 'This library contains a utility class that is composed of static methods that can be used for checking and validation of both objects and primitives.')
@@ -112,32 +111,32 @@ bintray {
     key = System.getenv('BINTRAY_KEY')
     publications = ['UtilsPublication']
     pkg {
-    	repo = 'kori_47'
-    	name = 'utils'
-		desc = 'This library contains a utility class that is composed of static methods that can be used for checking and validation of both objects and primitives.'
-		websiteUrl = 'https://github.com/kennedykori/JavaUtils'
-		issueTrackerUrl = 'https://github.com/kennedykori/JavaUtils/issues'
-    	vcsUrl = 'https://github.com/kennedykori/JavaUtils.git'
-    	licenses = ['MIT']
-    	labels = ['java', 'utils', 'utility']
-		publicDownloadNumbers = true
-		
-		githubRepo = 'kennedykori/JavaUtils'
-		githubReleaseNotesFile = 'doc-files/release-notes-1.1.0.md'
-		
-		version {
-	        name = '1.1.0'
-	        desc = 'Utils 1.1.0'
-	        released  = new Date()
-	        vcsTag = '1.1.0'
-			// GPG Signing
-			gpg {
+        repo = 'kori_47'
+        name = 'utils'
+        desc = 'This library contains a utility class that is composed of static methods that can be used for checking and validation of both objects and primitives.'
+        websiteUrl = 'https://github.com/kennedykori/JavaUtils'
+        issueTrackerUrl = 'https://github.com/kennedykori/JavaUtils/issues'
+        vcsUrl = 'https://github.com/kennedykori/JavaUtils.git'
+        licenses = ['MIT']
+        labels = ['java', 'utils', 'utility']
+        publicDownloadNumbers = true
+
+        githubRepo = 'kennedykori/JavaUtils'
+        githubReleaseNotesFile = 'doc-files/release-notes-1.2.0.md'
+
+        version {
+            name = '1.2.0'
+            desc = 'Utils 1.2.0'
+            released  = new Date()
+            vcsTag = '1.2.0'
+            // GPG Signing
+            gpg {
                 sign = true
-			}
-			// Maven Central Sync
-			mavenCentralSync {
-				sync = true
-			}
-	    }
+            }
+            // Maven Central Sync
+            mavenCentralSync {
+                sync = true
+            }
+        }
     }
 }

--- a/doc-files/release-notes-1.2.0.md
+++ b/doc-files/release-notes-1.2.0.md
@@ -1,0 +1,82 @@
+# Java Utils v1.2.0
+
+## Introduction
+
+The following notes describe important changes and information about this release.
+
+## Upgrade Instructions
+
+For [gradle](https://gradle.org/) users, switch to version 1.2.0 by updating your `build.gradle` 
+dependencies to:
+
+```gradle
+dependencies {
+    api 'com.kori_47:utils:1.2.0'
+    // other dependencies
+}
+```
+
+For maven users, update your `pom` file to:
+
+```xml
+<dependency>
+    <groupId>com.kori_47</groupId>
+    <artifactId>utils</artifactId>
+    <version>1.2.0</version>
+    <type>pom</type>
+</dependency>
+```
+
+### Compatibility Notes
+
+This release was tested on Java 8 and is expected to work well on Java 8 and later versions. 
+It may or may not work on earlier versions of Java.
+
+This version was tested with [junit 5](https://junit.org/junit5/).
+
+## What's New
+
+The following static utility methods were added in these release:
+
+* Methods for checking if a number is equal to a given base value.
+* Methods for validating if a number is equal to a given base value.
+
+The utility methods above can be divided into _checkers_ and _validators_.
+
+### Checkers
+
+These are methods that take a value and check if it meets a given condition and if so, 
+returns `true`, else, returns `false`. These methods are:
+
+1. *__isEqualTo__*
+
+    This are methods that check if a number is equal to a given baseValue. These methods 
+    have the following form:
+
+    ```java
+    public final static boolean isEqualTo(<type> baseValue, <type> value){ /* method body */ };
+    ```
+
+    There are five variants of the method above, where `<type>` can be one of the following: `int`, 
+    `long`, `float`, `double` or `java.math.BigDecimal`.
+
+### Validators
+
+These are methods that take a value and validate if it meets a given condition and if so, 
+returns the value, else, throws a `java.lang.IllegalArgumentException`. These methods are:
+
+1. *__requireEqualTo__*
+    
+    This are methods that validate if a number is equal to a given baseValue. These methods 
+    have the following form:
+
+    ```java
+    public final static <type> requireEqualTo(<type> baseValue, <type> value){ /* method body */ };
+    ```
+
+    There are five variants of the method above, where `<type>` can be one of the following: `int`, 
+    `long`, `float`, `double` or `java.math.BigDecimal`.
+
+## Reporting Problems
+
+If you find a problem with this release, please file a bug on [GitHub Issues](https://github.com/kennedykori/JavaUtils/issues).

--- a/src/main/java/com/kori_47/utils/ObjectUtils.java
+++ b/src/main/java/com/kori_47/utils/ObjectUtils.java
@@ -3,10 +3,13 @@
  */
 package com.kori_47.utils;
 
-import static java.util.Objects.*;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static java.util.Objects.requireNonNull;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+
 
 /**
  * This class consists of static utility methods<i>(similar to
@@ -54,22 +57,15 @@ import java.math.BigDecimal;
  */
 public final class ObjectUtils {
 
-	/*-------------------------------------------------------------------------------------
-	 * 
-	 * NUMBERS
-	 *
-	 * ------------------------------------------------------------------------------------
-	 */
-	/*
-	 * ------------------------------------ IS EQUAL
-	 * ------------------------------------
-	 */
+	// ========================================================================
+	// IS EQUAL CHECKS
+	// ========================================================================
 	/**
-	 * Checks if an {@code int} is equal to a supplied base value. Returns {@code true} if the
-	 * given {@code int} is equal to the supplied base value.
+	 * Checks if an {@code int} is equal to a supplied base value. Returns
+	 * {@code true} if the given {@code int} is equal to the supplied base value.
 	 * 
 	 * @param baseValue the value to compare for equality to.
-	 * @param value the value to check for equality.
+	 * @param value     the value to check for equality.
 	 * @return {@code true} if {@code value} is equal to {@code baseValue}.
 	 * 
 	 * @since 1.2.0
@@ -79,11 +75,11 @@ public final class ObjectUtils {
 	}
 
 	/**
-	 * Checks if a {@code long} is equal to a supplied base value. Returns {@code true} if the
-	 * given {@code long} is equal to the supplied base value.
+	 * Checks if a {@code long} is equal to a supplied base value. Returns
+	 * {@code true} if the given {@code long} is equal to the supplied base value.
 	 * 
 	 * @param baseValue the value to compare for equality to.
-	 * @param value the value to check for equality.
+	 * @param value     the value to check for equality.
 	 * @return {@code true} if {@code value} is equal to {@code baseValue}.
 	 * 
 	 * @since 1.2.0
@@ -91,7 +87,7 @@ public final class ObjectUtils {
 	public final static boolean isEqualTo(long baseValue, long value) {
 		return baseValue == value;
 	}
-	
+
 	/**
 	 * Checks if a {@code float} is equal to a supplied base value. Returns
 	 * {@code true} if the given {@code float} is equal to the supplied base
@@ -101,7 +97,7 @@ public final class ObjectUtils {
 	 * {@link Float#compare(float, float)} to compare the given values. </i>
 	 * 
 	 * @param baseValue the value to compare for equality to.
-	 * @param value the value to check for equality.
+	 * @param value     the value to check for equality.
 	 * 
 	 * @return {@code true} if {@code value} is equal to {@code baseValue}.
 	 * 
@@ -113,14 +109,14 @@ public final class ObjectUtils {
 
 	/**
 	 * Checks if a {@code double} is equal to a supplied base value. Returns
-	 * {@code true} if the given {@code double} is equal to the supplied base
-	 * value. <br>
+	 * {@code true} if the given {@code double} is equal to the supplied base value.
+	 * <br>
 	 * <br>
 	 * <i> <strong>NOTE:</strong> This method uses
 	 * {@link Double#compare(double, double)} to compare the given values. </i>
 	 * 
 	 * @param baseValue the value to compare for equality to.
-	 * @param value the value to check for equality.
+	 * @param value     the value to check for equality.
 	 * 
 	 * @return {@code true} if {@code value} is equal to {@code baseValue}.
 	 * 
@@ -132,11 +128,11 @@ public final class ObjectUtils {
 
 	/**
 	 * Checks if a {@link BigDecimal} is equal to a supplied base value. Returns
-	 * {@code true} if the given {@code BigDecimal} is equal to the supplied
-	 * base value.
+	 * {@code true} if the given {@code BigDecimal} is equal to the supplied base
+	 * value.
 	 * 
 	 * @param baseValue the value to compare for equality to.
-	 * @param value the value to check for equality.
+	 * @param value     the value to check for equality.
 	 * 
 	 * @return {@code true} if {@code value} is greater than {@code baseValue}.
 	 * 
@@ -149,19 +145,16 @@ public final class ObjectUtils {
 				.compareTo(requireNonNull(baseValue, "baseValue cannot be null.")) == 0;
 	}
 
-	/*
-	 * ------------------------------------ IS GREATER THAN
-	 * ------------------------------------
-	 */
+	// ========================================================================
+	// IS GREATER THAN CHECKS
+	// ========================================================================
 	/**
 	 * Checks if an {@code int} is greater than a supplied base value. Returns
 	 * {@code true} if the given {@code int} is greater than the supplied base
 	 * value.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness against.
-	 * @param value
-	 *            the value to check for greatness.
+	 * @param baseValue the value to compare for greatness against.
+	 * @param value     the value to check for greatness.
 	 * 
 	 * @return {@code true} if {@code value} is greater than {@code baseValue}.
 	 * 
@@ -176,10 +169,8 @@ public final class ObjectUtils {
 	 * {@code true} if the given {@code long} is greater than the supplied base
 	 * value.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness against.
-	 * @param value
-	 *            the value to check for greatness.
+	 * @param baseValue the value to compare for greatness against.
+	 * @param value     the value to check for greatness.
 	 * 
 	 * @return {@code true} if {@code value} is greater than {@code baseValue}.
 	 * 
@@ -197,10 +188,8 @@ public final class ObjectUtils {
 	 * <i> <strong>NOTE:</strong> This method uses
 	 * {@link Float#compare(float, float)} to compare the given values. </i>
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness against.
-	 * @param value
-	 *            the value to check for greatness.
+	 * @param baseValue the value to compare for greatness against.
+	 * @param value     the value to check for greatness.
 	 * 
 	 * @return {@code true} if {@code value} is greater than {@code baseValue}.
 	 * 
@@ -218,10 +207,8 @@ public final class ObjectUtils {
 	 * <i> <strong>NOTE:</strong> This method uses
 	 * {@link Double#compare(double, double)} to compare the given values. </i>
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness against.
-	 * @param value
-	 *            the value to check for greatness.
+	 * @param baseValue the value to compare for greatness against.
+	 * @param value     the value to check for greatness.
 	 * 
 	 * @return {@code true} if {@code value} is greater than {@code baseValue}.
 	 * 
@@ -236,15 +223,12 @@ public final class ObjectUtils {
 	 * {@code true} if the given {@code BigDecimal} is greater than the supplied
 	 * base value.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness against.
-	 * @param value
-	 *            the value to check for greatness.
+	 * @param baseValue the value to compare for greatness against.
+	 * @param value     the value to check for greatness.
 	 * 
 	 * @return {@code true} if {@code value} is greater than {@code baseValue}.
 	 * 
-	 * @throws NullPointerException
-	 *             if any of the two arguments is/are {@code null}.
+	 * @throws NullPointerException if any of the two arguments is/are {@code null}.
 	 *
 	 * @since 1.1.0
 	 */
@@ -253,19 +237,16 @@ public final class ObjectUtils {
 				.compareTo(requireNonNull(baseValue, "baseValue cannot be null.")) > 0;
 	}
 
-	/*
-	 * ------------------------------------ IS GREATER THAN OR EQUAL TO
-	 * ------------------------------------
-	 */
+	// ========================================================================
+	// IS GREATER THAN OR EQUAL TO CHECKS
+	// ========================================================================
 	/**
 	 * Checks if an {@code int} is greater than or equal to a supplied base value.
 	 * Returns {@code true} if the given {@code int} is greater than or equal to the
 	 * supplied base value.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness or equality against.
-	 * @param value
-	 *            the value to check for greatness or equality.
+	 * @param baseValue the value to compare for greatness or equality against.
+	 * @param value     the value to check for greatness or equality.
 	 * 
 	 * @return {@code true} if {@code value} is greater than or equal to
 	 *         {@code baseValue}.
@@ -281,10 +262,8 @@ public final class ObjectUtils {
 	 * Returns {@code true} if the given {@code long} is greater than or equal to
 	 * the supplied base value.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness or equality against.
-	 * @param value
-	 *            the value to check for greatness or equality.
+	 * @param baseValue the value to compare for greatness or equality against.
+	 * @param value     the value to check for greatness or equality.
 	 * 
 	 * @return {@code true} if {@code value} is greater than or equal to
 	 *         {@code baseValue}.
@@ -303,10 +282,8 @@ public final class ObjectUtils {
 	 * <i> <strong>NOTE:</strong> This method uses
 	 * {@link Float#compare(float, float)} to compare the given values. </i>
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness or equality against.
-	 * @param value
-	 *            the value to check for greatness or equality.
+	 * @param baseValue the value to compare for greatness or equality against.
+	 * @param value     the value to check for greatness or equality.
 	 * 
 	 * @return {@code true} if {@code value} is greater than or equal to
 	 *         {@code baseValue}.
@@ -325,10 +302,8 @@ public final class ObjectUtils {
 	 * <i> <strong>NOTE:</strong> This method uses
 	 * {@link Double#compare(double, double)} to compare the given values. </i>
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness or equality against.
-	 * @param value
-	 *            the value to check for greatness or equality.
+	 * @param baseValue the value to compare for greatness or equality against.
+	 * @param value     the value to check for greatness or equality.
 	 * 
 	 * @return {@code true} if {@code value} is greater than or equal to
 	 *         {@code baseValue}.
@@ -344,16 +319,13 @@ public final class ObjectUtils {
 	 * value. Returns {@code true} if the given {@code BigDecimal} is greater than
 	 * or equal to the supplied base value.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness or equality against.
-	 * @param value
-	 *            the value to check for greatness or equality.
+	 * @param baseValue the value to compare for greatness or equality against.
+	 * @param value     the value to check for greatness or equality.
 	 * 
 	 * @return {@code true} if {@code value} is greater than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws NullPointerException
-	 *             if any of the two arguments is/are {@code null}.
+	 * @throws NullPointerException if any of the two arguments is/are {@code null}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -362,17 +334,15 @@ public final class ObjectUtils {
 				.compareTo(requireNonNull(baseValue, "baseValue cannot be null.")) >= 0;
 	}
 
-	/*
-	 * ------------------------------------ IS NEGATIVE
-	 * ------------------------------------
-	 */
+	// ========================================================================
+	// IS NEGATIVE CHECKS
+	// ========================================================================
 	/**
 	 * Checks if an integer is negative, i.e, less than 0 and returns
 	 * <code>true</code> if the integer is negative, otherwise returns
 	 * <code>false</code>
 	 * 
-	 * @param value
-	 *            the integer to check
+	 * @param value the integer to check
 	 * @return <code>true</code> if the integer is negative, otherwise returns
 	 *         <code>false</code>
 	 */
@@ -384,8 +354,7 @@ public final class ObjectUtils {
 	 * Checks if a long is negative, i.e, less than 0 and returns <code>true</code>
 	 * if the long is negative, otherwise returns <code>false</code>
 	 * 
-	 * @param value
-	 *            the long to check
+	 * @param value the long to check
 	 * @return <code>true</code> if the long is negative, otherwise returns
 	 *         <code>false</code>
 	 */
@@ -397,8 +366,7 @@ public final class ObjectUtils {
 	 * Checks if a float is negative, i.e, less than 0 and returns <code>true</code>
 	 * if the float is negative, otherwise returns <code>false</code>
 	 * 
-	 * @param value
-	 *            the float to check
+	 * @param value the float to check
 	 * @return <code>true</code> if the float is negative, otherwise returns
 	 *         <code>false</code>
 	 */
@@ -411,8 +379,7 @@ public final class ObjectUtils {
 	 * <code>true</code> if the double is negative, otherwise returns
 	 * <code>false</code>
 	 * 
-	 * @param value
-	 *            the double to check
+	 * @param value the double to check
 	 * @return <code>true</code> if the double is negative, otherwise returns
 	 *         <code>false</code>
 	 */
@@ -424,31 +391,26 @@ public final class ObjectUtils {
 	 * Checks if a {@link BigDecimal} is negative, i.e, less than 0 and returns
 	 * <code>true</code>, otherwise returns <code>false</code>
 	 * 
-	 * @param value
-	 *            the <code>BigDecimal</code> to check
+	 * @param value the <code>BigDecimal</code> to check
 	 * 
 	 * @return <code>true</code> if the <code>BigDecimal</code> is negative,
 	 *         otherwise returns <code>false</code>
 	 * 
-	 * @throws NullPointerException
-	 *             if value is <code>null</code>.
+	 * @throws NullPointerException if value is <code>null</code>.
 	 */
 	public final static boolean isNegative(BigDecimal value) {
 		return requireNonNull(value).signum() < 0;
 	}
 
-	/*
-	 * ------------------------------------ IS LESS THAN
-	 * ------------------------------------
-	 */
+	// ========================================================================
+	// IS LESS THAN CHECKS
+	// ========================================================================
 	/**
 	 * Checks if an {@code int} is less than a supplied base value. Returns
 	 * {@code true} if the given {@code int} is less than the supplied base value.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness against.
-	 * @param value
-	 *            the value to check for smallness.
+	 * @param baseValue the value to compare for smallness against.
+	 * @param value     the value to check for smallness.
 	 * 
 	 * @return {@code true} if {@code value} is less than {@code baseValue}.
 	 * 
@@ -462,10 +424,8 @@ public final class ObjectUtils {
 	 * Checks if a {@code long} is less than a supplied base value. Returns
 	 * {@code true} if the given {@code long} is less than the supplied base value.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness against.
-	 * @param value
-	 *            the value to check for smallness.
+	 * @param baseValue the value to compare for smallness against.
+	 * @param value     the value to check for smallness.
 	 * 
 	 * @return {@code true} if {@code value} is less than {@code baseValue}.
 	 * 
@@ -483,10 +443,8 @@ public final class ObjectUtils {
 	 * <i> <strong>NOTE:</strong> This method uses
 	 * {@link Float#compare(float, float)} to compare the given values. </i>
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness against.
-	 * @param value
-	 *            the value to check for smallness.
+	 * @param baseValue the value to compare for smallness against.
+	 * @param value     the value to check for smallness.
 	 * 
 	 * @return {@code true} if {@code value} is less than {@code baseValue}.
 	 * 
@@ -504,10 +462,8 @@ public final class ObjectUtils {
 	 * <i> <strong>NOTE:</strong> This method uses
 	 * {@link Double#compare(double, double)} to compare the given values. </i>
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness against.
-	 * @param value
-	 *            the value to check for smallness.
+	 * @param baseValue the value to compare for smallness against.
+	 * @param value     the value to check for smallness.
 	 * 
 	 * @return {@code true} if {@code value} is less than {@code baseValue}.
 	 * 
@@ -522,15 +478,12 @@ public final class ObjectUtils {
 	 * {@code true} if the given {@code BigDecimal} is less than the supplied base
 	 * value.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness against.
-	 * @param value
-	 *            the value to check for smallness.
+	 * @param baseValue the value to compare for smallness against.
+	 * @param value     the value to check for smallness.
 	 * 
 	 * @return {@code true} if {@code value} is less than {@code baseValue}.
 	 * 
-	 * @throws NullPointerException
-	 *             if any of the two arguments is/are {@code null}.
+	 * @throws NullPointerException if any of the two arguments is/are {@code null}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -539,19 +492,16 @@ public final class ObjectUtils {
 				.compareTo(requireNonNull(baseValue, "baseValue cannot be null.")) < 0;
 	}
 
-	/*
-	 * ------------------------------------ IS LESS THAN OR EQUAL TO
-	 * ------------------------------------
-	 */
+	// ========================================================================
+	// IS LESS THAN OR EQUAL TO CHECKS
+	// ========================================================================
 	/**
 	 * Checks if an {@code int} is less than or equal to a supplied base value.
 	 * Returns {@code true} if the given {@code int} is less than or equal to the
 	 * supplied base value.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness or equality against.
-	 * @param value
-	 *            the value to check for smallness or equality.
+	 * @param baseValue the value to compare for smallness or equality against.
+	 * @param value     the value to check for smallness or equality.
 	 * 
 	 * @return {@code true} if {@code value} is less than or equal to
 	 *         {@code baseValue}.
@@ -567,10 +517,8 @@ public final class ObjectUtils {
 	 * Returns {@code true} if the given {@code long} is less than or equal to the
 	 * supplied base value.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness or equality against.
-	 * @param value
-	 *            the value to check for smallness or equality.
+	 * @param baseValue the value to compare for smallness or equality against.
+	 * @param value     the value to check for smallness or equality.
 	 * 
 	 * @return {@code true} if {@code value} is less than or equal to
 	 *         {@code baseValue}.
@@ -589,10 +537,8 @@ public final class ObjectUtils {
 	 * <i> <strong>NOTE:</strong> This method uses
 	 * {@link Float#compare(float, float)} to compare the given values. </i>
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness or equality against.
-	 * @param value
-	 *            the value to check for smallness or equality.
+	 * @param baseValue the value to compare for smallness or equality against.
+	 * @param value     the value to check for smallness or equality.
 	 * 
 	 * @return {@code true} if {@code value} is less than or equal to
 	 *         {@code baseValue}.
@@ -611,10 +557,8 @@ public final class ObjectUtils {
 	 * <i> <strong>NOTE:</strong> This method uses
 	 * {@link Double#compare(double, double)} to compare the given values. </i>
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness or equality against.
-	 * @param value
-	 *            the value to check for smallness or equality.
+	 * @param baseValue the value to compare for smallness or equality against.
+	 * @param value     the value to check for smallness or equality.
 	 * 
 	 * @return {@code true} if {@code value} is less than or equal to
 	 *         {@code baseValue}.
@@ -630,16 +574,13 @@ public final class ObjectUtils {
 	 * value. Returns {@code true} if the given {@code BigDecimal} is less than or
 	 * equal to the supplied base value.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness or equality against.
-	 * @param value
-	 *            the value to check for smallness or equality.
+	 * @param baseValue the value to compare for smallness or equality against.
+	 * @param value     the value to check for smallness or equality.
 	 * 
 	 * @return {@code true} if {@code value} is less than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws NullPointerException
-	 *             if any of the two arguments is/are {@code null}.
+	 * @throws NullPointerException if any of the two arguments is/are {@code null}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -648,10 +589,9 @@ public final class ObjectUtils {
 				.compareTo(requireNonNull(baseValue, "baseValue cannot be null.")) <= 0;
 	}
 
-	/*
-	 * ------------------------------------ IN RANGE
-	 * ------------------------------------
-	 */
+	// ========================================================================
+	// IN RANGE CHECKS
+	// ========================================================================
 	/**
 	 * Checks that the specified <code>Integer</code> is in range of the specified
 	 * minimum value (inclusive) and maximum value (exclusive). Returns
@@ -660,19 +600,16 @@ public final class ObjectUtils {
 	 * otherwise. An {@link IllegalArgumentException} will be thrown if the maximum
 	 * value is less than the minimum value.
 	 * 
-	 * @param minValue
-	 *            the minimum value(inclusive) of the range.
-	 * @param maxValue
-	 *            the maximum value(exclusive) of the range.
-	 * @param value
-	 *            the integer to check.
+	 * @param minValue the minimum value(inclusive) of the range.
+	 * @param maxValue the maximum value(exclusive) of the range.
+	 * @param value    the integer to check.
 	 * 
 	 * @return <code>true</code> if <code>value</code> is greater than or equal to
 	 *         <code>minValue</code> and less than <code>maxValue</code>,
 	 *         <code>false</code> otherwise.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if <code>maxValue</code> is less than <code>minValue</code>.
+	 * @throws IllegalArgumentException if <code>maxValue</code> is less than
+	 *                                  <code>minValue</code>.
 	 */
 	public final static boolean inRange(int minValue, int maxValue, int value) {
 		requireGreaterThanOrEqualTo(minValue, maxValue,
@@ -688,19 +625,16 @@ public final class ObjectUtils {
 	 * otherwise. An {@link IllegalArgumentException} will be thrown if the maximum
 	 * value is less than the minimum value.
 	 * 
-	 * @param minValue
-	 *            the minimum value(inclusive) of the range.
-	 * @param maxValue
-	 *            the maximum value(exclusive) of the range.
-	 * @param value
-	 *            the long to check.
+	 * @param minValue the minimum value(inclusive) of the range.
+	 * @param maxValue the maximum value(exclusive) of the range.
+	 * @param value    the long to check.
 	 * 
 	 * @return <code>true</code> if <code>value</code> is greater than or equal to
 	 *         <code>minValue</code> and less than <code>maxValue</code>,
 	 *         <code>false</code> otherwise.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if <code>maxValue</code> is less than <code>minValue</code>.
+	 * @throws IllegalArgumentException if <code>maxValue</code> is less than
+	 *                                  <code>minValue</code>.
 	 */
 	public final static boolean inRange(long minValue, long maxValue, long value) {
 		requireGreaterThanOrEqualTo(minValue, maxValue,
@@ -716,19 +650,16 @@ public final class ObjectUtils {
 	 * otherwise. An {@link IllegalArgumentException} will be thrown if the maximum
 	 * value is less than the minimum value.
 	 * 
-	 * @param minValue
-	 *            the minimum value(inclusive) of the range.
-	 * @param maxValue
-	 *            the maximum value(exclusive) of the range.
-	 * @param value
-	 *            the float to check.
+	 * @param minValue the minimum value(inclusive) of the range.
+	 * @param maxValue the maximum value(exclusive) of the range.
+	 * @param value    the float to check.
 	 * 
 	 * @return <code>true</code> if <code>value</code> is greater than or equal to
 	 *         <code>minValue</code> and less than <code>maxValue</code>,
 	 *         <code>false</code> otherwise.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if <code>maxValue</code> is less than <code>minValue</code>.
+	 * @throws IllegalArgumentException if <code>maxValue</code> is less than
+	 *                                  <code>minValue</code>.
 	 */
 	public final static boolean inRange(float minValue, float maxValue, float value) {
 		requireGreaterThanOrEqualTo(minValue, maxValue,
@@ -744,19 +675,16 @@ public final class ObjectUtils {
 	 * otherwise. An {@link IllegalArgumentException} will be thrown if the maximum
 	 * value is less than the minimum value.
 	 * 
-	 * @param minValue
-	 *            the minimum value(inclusive) of the range.
-	 * @param maxValue
-	 *            the maximum value(exclusive) of the range.
-	 * @param value
-	 *            the double to check.
+	 * @param minValue the minimum value(inclusive) of the range.
+	 * @param maxValue the maximum value(exclusive) of the range.
+	 * @param value    the double to check.
 	 * 
 	 * @return <code>true</code> if <code>value</code> is greater than or equal to
 	 *         <code>minValue</code> and less than <code>maxValue</code>,
 	 *         <code>false</code> otherwise.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if <code>maxValue</code> is less than <code>minValue</code>.
+	 * @throws IllegalArgumentException if <code>maxValue</code> is less than
+	 *                                  <code>minValue</code>.
 	 */
 	public final static boolean inRange(double minValue, double maxValue, double value) {
 		requireGreaterThanOrEqualTo(minValue, maxValue,
@@ -772,21 +700,18 @@ public final class ObjectUtils {
 	 * otherwise. An {@link IllegalArgumentException} will be thrown if the maximum
 	 * value is less than the minimum value.
 	 * 
-	 * @param minValue
-	 *            the minimum value(inclusive) of the range.
-	 * @param maxValue
-	 *            the maximum value(exclusive) of the range.
-	 * @param value
-	 *            the <code>BigDecimal</code> to check.
+	 * @param minValue the minimum value(inclusive) of the range.
+	 * @param maxValue the maximum value(exclusive) of the range.
+	 * @param value    the <code>BigDecimal</code> to check.
 	 * 
 	 * @return <code>true</code> if <code>value</code> is greater than or equal to
 	 *         <code>minValue</code> and less than <code>maxValue</code>,
 	 *         <code>false</code> otherwise.
 	 * 
-	 * @throws NullPointerException
-	 *             if any of the arguments passed are <code>null</code>.
-	 * @throws IllegalArgumentException
-	 *             if <code>maxValue</code> is less than <code>minValue</code>.
+	 * @throws NullPointerException     if any of the arguments passed are
+	 *                                  <code>null</code>.
+	 * @throws IllegalArgumentException if <code>maxValue</code> is less than
+	 *                                  <code>minValue</code>.
 	 */
 	public final static boolean inRange(BigDecimal minValue, BigDecimal maxValue, BigDecimal value) {
 		requireGreaterThanOrEqualTo(minValue, maxValue,
@@ -794,22 +719,21 @@ public final class ObjectUtils {
 		return isGreaterThanOrEqualTo(minValue, value) && isLessThan(maxValue, value);
 	}
 
-	/*
-	 * ------------------------------------ REQUIRE EQUAL TO
-	 * ------------------------------------
-	 */
-
+	// ========================================================================
+	// REQUIRE EQUAL TO VALIDATORS
+	// ========================================================================
 	/**
-	 * Validates that an {@code int} is equal to a supplied base value. Returns
-	 * the given {@code int} if it is equal to the given base value, otherwise,
-	 * an {@code IllegalArgumentException} is thrown.
+	 * Validates that an {@code int} is equal to a supplied base value. Returns the
+	 * given {@code int} if it is equal to the given base value, otherwise, an
+	 * {@code IllegalArgumentException} is thrown.
 	 * 
 	 * @param baseValue the value to compare for equality to.
-	 * @param value the value to check for equality.
+	 * @param value     the value to check for equality.
 	 * 
 	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is not equal to
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.2.0
 	 */
@@ -818,38 +742,41 @@ public final class ObjectUtils {
 	}
 
 	/**
-	 * Validates that an {@code int} is equal to a supplied base value. Returns
-	 * the given {@code int} if it is equal to the given base value, otherwise,
-	 * an {@code IllegalArgumentException} is thrown.
+	 * Validates that an {@code int} is equal to a supplied base value. Returns the
+	 * given {@code int} if it is equal to the given base value, otherwise, an
+	 * {@code IllegalArgumentException} is thrown.
 	 * 
 	 * @param baseValue the value to compare for equality to.
-	 * @param value the value to check for equality.
-	 * @param message an optional message to be used as as the {@code IllegalArgumentException} message.
+	 * @param value     the value to check for equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is not equal to
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.2.0
 	 */
 	public final static int requireEqualTo(int baseValue, int value, String message) {
 		if (!isEqualTo(baseValue, value))
-			throw new IllegalArgumentException((nonNull(message) ? message
-					: String.format("value(%d) should be equal to %d.", value, baseValue)));
+			throw new IllegalArgumentException(
+					(nonNull(message) ? message : String.format("value(%d) should be equal to %d.", value, baseValue)));
 		return value;
 	}
 
 	/**
-	 * Validates that a {@code long} is equal to a supplied base value. Returns
-	 * the given {@code long} if it is equal to the given base value, otherwise,
-	 * an {@code IllegalArgumentException} is thrown.
+	 * Validates that a {@code long} is equal to a supplied base value. Returns the
+	 * given {@code long} if it is equal to the given base value, otherwise, an
+	 * {@code IllegalArgumentException} is thrown.
 	 * 
 	 * @param baseValue the value to compare for equality to.
-	 * @param value the value to check for equality.
+	 * @param value     the value to check for equality.
 	 * 
 	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is not equal to
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.2.0
 	 */
@@ -858,38 +785,41 @@ public final class ObjectUtils {
 	}
 
 	/**
-	 * Validates that a {@code long} is equal to a supplied base value. Returns
-	 * the given {@code long} if it is equal to the given base value, otherwise,
-	 * an {@code IllegalArgumentException} is thrown.
+	 * Validates that a {@code long} is equal to a supplied base value. Returns the
+	 * given {@code long} if it is equal to the given base value, otherwise, an
+	 * {@code IllegalArgumentException} is thrown.
 	 * 
 	 * @param baseValue the value to compare for equality to.
-	 * @param value the value to check for equality.
-	 * @param message an optional message to be used as as the {@code IllegalArgumentException} message.
+	 * @param value     the value to check for equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is not equal to
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.2.0
 	 */
 	public final static long requireEqualTo(long baseValue, long value, String message) {
 		if (!isEqualTo(baseValue, value))
-			throw new IllegalArgumentException((nonNull(message) ? message
-					: String.format("value(%d) should be equal to %d.", value, baseValue)));
+			throw new IllegalArgumentException(
+					(nonNull(message) ? message : String.format("value(%d) should be equal to %d.", value, baseValue)));
 		return value;
 	}
 
 	/**
-	 * Validates that a {@code long} is equal to a supplied base value. Returns
-	 * the given {@code long} if it is equal to the given base value, otherwise,
-	 * an {@code IllegalArgumentException} is thrown.
+	 * Validates that a {@code long} is equal to a supplied base value. Returns the
+	 * given {@code long} if it is equal to the given base value, otherwise, an
+	 * {@code IllegalArgumentException} is thrown.
 	 * 
 	 * @param baseValue the value to compare for equality to.
-	 * @param value the value to check for equality.
+	 * @param value     the value to check for equality.
 	 * 
 	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is not equal to
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.2.0
 	 */
@@ -898,24 +828,26 @@ public final class ObjectUtils {
 	}
 
 	/**
-	 * Validates that a {@code float} is equal to a supplied base value. Returns
-	 * the given {@code float} if it is equal to the given base value, otherwise,
-	 * an {@code IllegalArgumentException} is thrown.
+	 * Validates that a {@code float} is equal to a supplied base value. Returns the
+	 * given {@code float} if it is equal to the given base value, otherwise, an
+	 * {@code IllegalArgumentException} is thrown.
 	 * 
 	 * @param baseValue the value to compare for equality to.
-	 * @param value the value to check for equality.
-	 * @param message an optional message to be used as as the {@code IllegalArgumentException} message.
+	 * @param value     the value to check for equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is not equal to
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.2.0
 	 */
 	public final static float requireEqualTo(float baseValue, float value, String message) {
 		if (!isEqualTo(baseValue, value))
-			throw new IllegalArgumentException((nonNull(message) ? message
-					: String.format("value(%f) should be equal to %f.", value, baseValue)));
+			throw new IllegalArgumentException(
+					(nonNull(message) ? message : String.format("value(%f) should be equal to %f.", value, baseValue)));
 		return value;
 	}
 
@@ -925,11 +857,12 @@ public final class ObjectUtils {
 	 * an {@code IllegalArgumentException} is thrown.
 	 * 
 	 * @param baseValue the value to compare for equality to.
-	 * @param value the value to check for equality.
+	 * @param value     the value to check for equality.
 	 * 
 	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is not equal to
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.2.0
 	 */
@@ -943,35 +876,40 @@ public final class ObjectUtils {
 	 * an {@code IllegalArgumentException} is thrown.
 	 * 
 	 * @param baseValue the value to compare for equality to.
-	 * @param value the value to check for equality.
-	 * @param message an optional message to be used as as the {@code IllegalArgumentException} message.
+	 * @param value     the value to check for equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is not equal to
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.2.0
 	 */
 	public final static double requireEqualTo(double baseValue, double value, String message) {
 		if (!isEqualTo(baseValue, value))
-			throw new IllegalArgumentException((nonNull(message) ? message
-					: String.format("value(%f) should be equal to %f.", value, baseValue)));
+			throw new IllegalArgumentException(
+					(nonNull(message) ? message : String.format("value(%f) should be equal to %f.", value, baseValue)));
 		return value;
 	}
 
 	/**
-	 * Validates that a {@link BigDecimal} is equal to a supplied base value. Returns
-	 * the given {@code BigDecimal} if it is equal to the given base value, otherwise,
-	 * an {@code IllegalArgumentException} is thrown.
+	 * Validates that a {@link BigDecimal} is equal to a supplied base value.
+	 * Returns the given {@code BigDecimal} if it is equal to the given base value,
+	 * otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
 	 * @param baseValue the value to compare for equality to.
-	 * @param value the value to check for equality.
-	 * @param message an optional message to be used as as the {@code IllegalArgumentException} message.
+	 * @param value     the value to check for equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
-	 * @throws NullPointerException if {@code baseValue} or/and {@code value} is/are {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is not equal to
+	 *                                  {@code baseValue}.
+	 * @throws NullPointerException     if {@code baseValue} or/and {@code value}
+	 *                                  is/are {@code null}.
 	 * 
 	 * @since 1.2.0
 	 */
@@ -980,47 +918,46 @@ public final class ObjectUtils {
 	}
 
 	/**
-	 * Validates that a {@link BigDecimal} is equal to a supplied base value. Returns
-	 * the given {@code BigDecimal} if it is equal to the given base value, otherwise,
-	 * an {@code IllegalArgumentException} is thrown.
+	 * Validates that a {@link BigDecimal} is equal to a supplied base value.
+	 * Returns the given {@code BigDecimal} if it is equal to the given base value,
+	 * otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
 	 * @param baseValue the value to compare for equality to.
-	 * @param value the value to check for equality.
-	 * @param message an optional message to be used as as the {@code IllegalArgumentException} message.
+	 * @param value     the value to check for equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
-	 * @throws NullPointerException if {@code baseValue} or/and {@code value} is/are {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is not equal to
+	 *                                  {@code baseValue}.
+	 * @throws NullPointerException     if {@code baseValue} or/and {@code value}
+	 *                                  is/are {@code null}.
 	 * 
 	 * @since 1.2.0
 	 */
 	public final static BigDecimal requireEqualTo(BigDecimal baseValue, BigDecimal value, String message) {
 		if (!isEqualTo(baseValue, value))
-			throw new IllegalArgumentException((nonNull(message) ? message
-					: String.format("value(%s) should be equal to %s.", value, baseValue)));
+			throw new IllegalArgumentException(
+					(nonNull(message) ? message : String.format("value(%s) should be equal to %s.", value, baseValue)));
 		return value;
 	}
 
-	/*
-	 * ------------------------------------ REQUIRE GREATER THAN
-	 * ------------------------------------
-	 */
-
+	// ========================================================================
+	// REQUIRE GREATER THAN VALIDATORS
+	// ========================================================================
 	/**
 	 * Validates that an {@code int} is greater than a supplied base value. Returns
 	 * the given {@code int} if it is greater than the given base value, otherwise,
 	 * an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness against.
-	 * @param value
-	 *            the value to check for greatness.
+	 * @param baseValue the value to compare for greatness against.
+	 * @param value     the value to check for greatness.
 	 * 
 	 * @return {@code value} if {@code value} is greater than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1033,18 +970,15 @@ public final class ObjectUtils {
 	 * the given {@code int} if it is greater than the given base value, otherwise,
 	 * an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness against.
-	 * @param value
-	 *            the value to check for greatness.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for greatness against.
+	 * @param value     the value to check for greatness.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is greater than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1060,15 +994,13 @@ public final class ObjectUtils {
 	 * the given {@code long} if it is greater than the given base value, otherwise,
 	 * an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness against.
-	 * @param value
-	 *            the value to check for greatness.
+	 * @param baseValue the value to compare for greatness against.
+	 * @param value     the value to check for greatness.
 	 * 
 	 * @return {@code value} if {@code value} is greater than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1081,18 +1013,15 @@ public final class ObjectUtils {
 	 * the given {@code long} if it is greater than the given base value, otherwise,
 	 * an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness against.
-	 * @param value
-	 *            the value to check for greatness.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for greatness against.
+	 * @param value     the value to check for greatness.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is greater than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1108,15 +1037,13 @@ public final class ObjectUtils {
 	 * the given {@code float} if it is greater than the given base value,
 	 * otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness against.
-	 * @param value
-	 *            the value to check for greatness.
+	 * @param baseValue the value to compare for greatness against.
+	 * @param value     the value to check for greatness.
 	 * 
 	 * @return {@code value} if {@code value} is greater than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1129,18 +1056,15 @@ public final class ObjectUtils {
 	 * the given {@code float} if it is greater than the given base value,
 	 * otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness against.
-	 * @param value
-	 *            the value to check for greatness.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for greatness against.
+	 * @param value     the value to check for greatness.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is greater than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1156,15 +1080,13 @@ public final class ObjectUtils {
 	 * Returns the given {@code double} if it is greater than the given base value,
 	 * otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness against.
-	 * @param value
-	 *            the value to check for greatness.
+	 * @param baseValue the value to compare for greatness against.
+	 * @param value     the value to check for greatness.
 	 * 
 	 * @return {@code value} if {@code value} is greater than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1177,18 +1099,15 @@ public final class ObjectUtils {
 	 * Returns the given {@code double} if it is greater than the given base value,
 	 * otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness against.
-	 * @param value
-	 *            the value to check for greatness.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for greatness against.
+	 * @param value     the value to check for greatness.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is greater than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1204,17 +1123,15 @@ public final class ObjectUtils {
 	 * Returns the given {@code BigDecimal} if it is greater than the given base
 	 * value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness against.
-	 * @param value
-	 *            the value to check for greatness.
+	 * @param baseValue the value to compare for greatness against.
+	 * @param value     the value to check for greatness.
 	 * 
 	 * @return {@code value} if {@code value} is greater than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
-	 * @throws NullPointerException
-	 *             if {@code baseValue} or/and {@code value} is/are {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
+	 * @throws NullPointerException     if {@code baseValue} or/and {@code value}
+	 *                                  is/are {@code null}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1227,20 +1144,17 @@ public final class ObjectUtils {
 	 * Returns the given {@code BigDecimal} if it is greater than the given base
 	 * value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness against.
-	 * @param value
-	 *            the value to check for greatness.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for greatness against.
+	 * @param value     the value to check for greatness.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is greater than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
-	 * @throws NullPointerException
-	 *             if {@code baseValue} or/and {@code value} is/are {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
+	 * @throws NullPointerException     if {@code baseValue} or/and {@code value}
+	 *                                  is/are {@code null}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1251,26 +1165,22 @@ public final class ObjectUtils {
 		return value;
 	}
 
-	/*
-	 * ------------------------------------ REQUIRE GREATER THAN OR EQUAL TO
-	 * ------------------------------------
-	 */
-
+	// ========================================================================
+	// REQUIRE GREATER THAN OR EQUAL TO VALIDATORS
+	// ========================================================================
 	/**
 	 * Validates that an {@code int} is greater than or equal to a supplied base
 	 * value. Returns the given {@code int} if it is greater than or equal to the
 	 * given base value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness or equality against.
-	 * @param value
-	 *            the value to check for greatness or equality.
+	 * @param baseValue the value to compare for greatness or equality against.
+	 * @param value     the value to check for greatness or equality.
 	 * 
 	 * @return {@code value} if {@code value} is greater than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1283,19 +1193,16 @@ public final class ObjectUtils {
 	 * value. Returns the given {@code int} if it is greater than or equal to the
 	 * given base value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness or equality against.
-	 * @param value
-	 *            the value to check for greatness or equality.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for greatness or equality against.
+	 * @param value     the value to check for greatness or equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is greater than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1311,16 +1218,14 @@ public final class ObjectUtils {
 	 * value. Returns the given {@code long} if it is greater than or equal to the
 	 * given base value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness or equality against.
-	 * @param value
-	 *            the value to check for greatness or equality.
+	 * @param baseValue the value to compare for greatness or equality against.
+	 * @param value     the value to check for greatness or equality.
 	 * 
 	 * @return {@code value} if {@code value} is greater than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1333,19 +1238,16 @@ public final class ObjectUtils {
 	 * value. Returns the given {@code long} if it is greater than or equal to the
 	 * given base value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness or equality against.
-	 * @param value
-	 *            the value to check for greatness or equality.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for greatness or equality against.
+	 * @param value     the value to check for greatness or equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is greater than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1361,16 +1263,14 @@ public final class ObjectUtils {
 	 * value. Returns the given {@code float} if it is greater than or equal to the
 	 * given base value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness or equality against.
-	 * @param value
-	 *            the value to check for greatness or equality.
+	 * @param baseValue the value to compare for greatness or equality against.
+	 * @param value     the value to check for greatness or equality.
 	 * 
 	 * @return {@code value} if {@code value} is greater than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1383,19 +1283,16 @@ public final class ObjectUtils {
 	 * value. Returns the given {@code float} if it is greater than or equal to the
 	 * given base value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness or equality against.
-	 * @param value
-	 *            the value to check for greatness or equality.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for greatness or equality against.
+	 * @param value     the value to check for greatness or equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is greater than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1411,16 +1308,14 @@ public final class ObjectUtils {
 	 * value. Returns the given {@code double} if it is greater than or equal to the
 	 * given base value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness or equality against.
-	 * @param value
-	 *            the value to check for greatness or equality.
+	 * @param baseValue the value to compare for greatness or equality against.
+	 * @param value     the value to check for greatness or equality.
 	 * 
 	 * @return {@code value} if {@code value} is greater than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1433,19 +1328,16 @@ public final class ObjectUtils {
 	 * value. Returns the given {@code double} if it is greater than or equal to the
 	 * given base value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness or equality against.
-	 * @param value
-	 *            the value to check for greatness or equality.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for greatness or equality against.
+	 * @param value     the value to check for greatness or equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is greater than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1462,18 +1354,16 @@ public final class ObjectUtils {
 	 * equal to the given base value, otherwise, an {@code IllegalArgumentException}
 	 * is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness or equality against.
-	 * @param value
-	 *            the value to check for greatness or equality.
+	 * @param baseValue the value to compare for greatness or equality against.
+	 * @param value     the value to check for greatness or equality.
 	 * 
 	 * @return {@code value} if {@code value} is greater than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
-	 * @throws NullPointerException
-	 *             if {@code baseValue} or/and {@code value} is/are {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
+	 * @throws NullPointerException     if {@code baseValue} or/and {@code value}
+	 *                                  is/are {@code null}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1487,21 +1377,18 @@ public final class ObjectUtils {
 	 * equal to the given base value, otherwise, an {@code IllegalArgumentException}
 	 * is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for greatness or equality against.
-	 * @param value
-	 *            the value to check for greatness or equality.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for greatness or equality against.
+	 * @param value     the value to check for greatness or equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is greater than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is less than {@code baseValue}.
-	 * @throws NullPointerException
-	 *             if {@code baseValue} or/and {@code value} is/are {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is less than
+	 *                                  {@code baseValue}.
+	 * @throws NullPointerException     if {@code baseValue} or/and {@code value}
+	 *                                  is/are {@code null}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -1512,10 +1399,9 @@ public final class ObjectUtils {
 		return value;
 	}
 
-	/*
-	 * ------------------------------------ REQUIRE IN RANGE
-	 * ------------------------------------
-	 */
+	// ========================================================================
+	// REQUIRE IN RANGE VALIDATORS
+	// ========================================================================
 	/**
 	 * Validates that the specified {@code int} is in range of the specified minimum
 	 * value <i><strong>(inclusive)</strong></i> and maximum value
@@ -1526,18 +1412,17 @@ public final class ObjectUtils {
 	 * {@code IllegalArgumentException} will also be thrown if the maximum value is
 	 * less than the minimum value.
 	 * 
-	 * @param minValue
-	 *            the minimum value<i><strong>(inclusive)</strong></i> of the range.
-	 * @param maxValue
-	 *            the maximum value<i><strong>(exclusive)</strong></i> of the range.
-	 * @param value
-	 *            the {@code int} to check.
+	 * @param minValue the minimum value<i><strong>(inclusive)</strong></i> of the
+	 *                 range.
+	 * @param maxValue the maximum value<i><strong>(exclusive)</strong></i> of the
+	 *                 range.
+	 * @param value    the {@code int} to check.
 	 * 
 	 * @return {@code value} if it is in the specified range.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is not in the specified range or if
-	 *             {@code maxValue} is less than {@code minValue}.
+	 * @throws IllegalArgumentException if {@code value} is not in the specified
+	 *                                  range or if {@code maxValue} is less than
+	 *                                  {@code minValue}.
 	 */
 	public final static int requireInRange(int minValue, int maxValue, int value) {
 		return requireInRange(minValue, maxValue, value, null);
@@ -1554,21 +1439,19 @@ public final class ObjectUtils {
 	 * less than the minimum value. An optional message can also be given to be used
 	 * as the exception message.
 	 * 
-	 * @param minValue
-	 *            the minimum value<i><strong>(inclusive)</strong></i> of the range.
-	 * @param maxValue
-	 *            the maximum value<i><strong>(exclusive)</strong></i> of the range.
-	 * @param value
-	 *            the {@code int} to check.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param minValue the minimum value<i><strong>(inclusive)</strong></i> of the
+	 *                 range.
+	 * @param maxValue the maximum value<i><strong>(exclusive)</strong></i> of the
+	 *                 range.
+	 * @param value    the {@code int} to check.
+	 * @param message  an optional message to be used as as the
+	 *                 {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if it is in the specified range.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is not in the specified range or if
-	 *             {@code maxValue} is less than {@code minValue}.
+	 * @throws IllegalArgumentException if {@code value} is not in the specified
+	 *                                  range or if {@code maxValue} is less than
+	 *                                  {@code minValue}.
 	 */
 	public final static int requireInRange(int minValue, int maxValue, int value, String message) {
 		if (!inRange(minValue, maxValue, value))
@@ -1588,18 +1471,17 @@ public final class ObjectUtils {
 	 * {@code IllegalArgumentException} will also be thrown if the maximum value is
 	 * less than the minimum value.
 	 * 
-	 * @param minValue
-	 *            the minimum value<i><strong>(inclusive)</strong></i> of the range.
-	 * @param maxValue
-	 *            the maximum value<i><strong>(exclusive)</strong></i> of the range.
-	 * @param value
-	 *            the {@code long} to check.
+	 * @param minValue the minimum value<i><strong>(inclusive)</strong></i> of the
+	 *                 range.
+	 * @param maxValue the maximum value<i><strong>(exclusive)</strong></i> of the
+	 *                 range.
+	 * @param value    the {@code long} to check.
 	 * 
 	 * @return {@code value} if it is in the specified range.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is not in the specified range or if
-	 *             {@code maxValue} is less than {@code minValue}.
+	 * @throws IllegalArgumentException if {@code value} is not in the specified
+	 *                                  range or if {@code maxValue} is less than
+	 *                                  {@code minValue}.
 	 */
 	public final static long requireInRange(long minValue, long maxValue, long value) {
 		return requireInRange(minValue, maxValue, value, null);
@@ -1616,21 +1498,19 @@ public final class ObjectUtils {
 	 * less than the minimum value. An optional message can also be given to be used
 	 * as the exception message.
 	 * 
-	 * @param minValue
-	 *            the minimum value<i><strong>(inclusive)</strong></i> of the range.
-	 * @param maxValue
-	 *            the maximum value<i><strong>(exclusive)</strong></i> of the range.
-	 * @param value
-	 *            the {@code long} to check.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param minValue the minimum value<i><strong>(inclusive)</strong></i> of the
+	 *                 range.
+	 * @param maxValue the maximum value<i><strong>(exclusive)</strong></i> of the
+	 *                 range.
+	 * @param value    the {@code long} to check.
+	 * @param message  an optional message to be used as as the
+	 *                 {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if it is in the specified range.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is not in the specified range or if
-	 *             {@code maxValue} is less than {@code minValue}.
+	 * @throws IllegalArgumentException if {@code value} is not in the specified
+	 *                                  range or if {@code maxValue} is less than
+	 *                                  {@code minValue}.
 	 */
 	public final static long requireInRange(long minValue, long maxValue, long value, String message) {
 		if (!inRange(minValue, maxValue, value))
@@ -1650,18 +1530,17 @@ public final class ObjectUtils {
 	 * {@code IllegalArgumentException} will also be thrown if the maximum value is
 	 * less than the minimum value.
 	 * 
-	 * @param minValue
-	 *            the minimum value<i><strong>(inclusive)</strong></i> of the range.
-	 * @param maxValue
-	 *            the maximum value<i><strong>(exclusive)</strong></i> of the range.
-	 * @param value
-	 *            the {@code float} to check.
+	 * @param minValue the minimum value<i><strong>(inclusive)</strong></i> of the
+	 *                 range.
+	 * @param maxValue the maximum value<i><strong>(exclusive)</strong></i> of the
+	 *                 range.
+	 * @param value    the {@code float} to check.
 	 * 
 	 * @return {@code value} if it is in the specified range.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is not in the specified range or if
-	 *             {@code maxValue} is less than {@code minValue}.
+	 * @throws IllegalArgumentException if {@code value} is not in the specified
+	 *                                  range or if {@code maxValue} is less than
+	 *                                  {@code minValue}.
 	 */
 	public final static float requireInRange(float minValue, float maxValue, float value) {
 		return requireInRange(minValue, maxValue, value, null);
@@ -1678,21 +1557,19 @@ public final class ObjectUtils {
 	 * less than the minimum value. An optional message can also be given to be used
 	 * as the exception message.
 	 * 
-	 * @param minValue
-	 *            the minimum value<i><strong>(inclusive)</strong></i> of the range.
-	 * @param maxValue
-	 *            the maximum value<i><strong>(exclusive)</strong></i> of the range.
-	 * @param value
-	 *            the {@code float} to check.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param minValue the minimum value<i><strong>(inclusive)</strong></i> of the
+	 *                 range.
+	 * @param maxValue the maximum value<i><strong>(exclusive)</strong></i> of the
+	 *                 range.
+	 * @param value    the {@code float} to check.
+	 * @param message  an optional message to be used as as the
+	 *                 {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if it is in the specified range.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is not in the specified range or if
-	 *             {@code maxValue} is less than {@code minValue}.
+	 * @throws IllegalArgumentException if {@code value} is not in the specified
+	 *                                  range or if {@code maxValue} is less than
+	 *                                  {@code minValue}.
 	 */
 	public final static float requireInRange(float minValue, float maxValue, float value, String message) {
 		if (!inRange(minValue, maxValue, value))
@@ -1712,18 +1589,17 @@ public final class ObjectUtils {
 	 * {@code IllegalArgumentException} will also be thrown if the maximum value is
 	 * less than the minimum value.
 	 * 
-	 * @param minValue
-	 *            the minimum value<i><strong>(inclusive)</strong></i> of the range.
-	 * @param maxValue
-	 *            the maximum value<i><strong>(exclusive)</strong></i> of the range.
-	 * @param value
-	 *            the {@code double} to check.
+	 * @param minValue the minimum value<i><strong>(inclusive)</strong></i> of the
+	 *                 range.
+	 * @param maxValue the maximum value<i><strong>(exclusive)</strong></i> of the
+	 *                 range.
+	 * @param value    the {@code double} to check.
 	 * 
 	 * @return {@code value} if it is in the specified range.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is not in the specified range or if
-	 *             {@code maxValue} is less than {@code minValue}.
+	 * @throws IllegalArgumentException if {@code value} is not in the specified
+	 *                                  range or if {@code maxValue} is less than
+	 *                                  {@code minValue}.
 	 */
 	public final static double requireInRange(double minValue, double maxValue, double value) {
 		return requireInRange(minValue, maxValue, value, null);
@@ -1740,21 +1616,19 @@ public final class ObjectUtils {
 	 * less than the minimum value. An optional message can also be given to be used
 	 * as the exception message.
 	 * 
-	 * @param minValue
-	 *            the minimum value<i><strong>(inclusive)</strong></i> of the range.
-	 * @param maxValue
-	 *            the maximum value<i><strong>(exclusive)</strong></i> of the range.
-	 * @param value
-	 *            the {@code double} to check.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param minValue the minimum value<i><strong>(inclusive)</strong></i> of the
+	 *                 range.
+	 * @param maxValue the maximum value<i><strong>(exclusive)</strong></i> of the
+	 *                 range.
+	 * @param value    the {@code double} to check.
+	 * @param message  an optional message to be used as as the
+	 *                 {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if it is in the specified range.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is not in the specified range or if
-	 *             {@code maxValue} is less than {@code minValue}.
+	 * @throws IllegalArgumentException if {@code value} is not in the specified
+	 *                                  range or if {@code maxValue} is less than
+	 *                                  {@code minValue}.
 	 */
 	public final static double requireInRange(double minValue, double maxValue, double value, String message) {
 		if (!inRange(minValue, maxValue, value))
@@ -1774,20 +1648,18 @@ public final class ObjectUtils {
 	 * {@code IllegalArgumentException} will also be thrown if the maximum value is
 	 * less than the minimum value.
 	 * 
-	 * @param minValue
-	 *            the minimum value<i><strong>(inclusive)</strong></i> of the range.
-	 * @param maxValue
-	 *            the maximum value<i><strong>(exclusive)</strong></i> of the range.
-	 * @param value
-	 *            the {@code BigDecimal} to check.
+	 * @param minValue the minimum value<i><strong>(inclusive)</strong></i> of the
+	 *                 range.
+	 * @param maxValue the maximum value<i><strong>(exclusive)</strong></i> of the
+	 *                 range.
+	 * @param value    the {@code BigDecimal} to check.
 	 * 
 	 * @return {@code value} if it is in the specified range.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is not in the specified range or if
-	 *             {@code maxValue} is less than {@code minValue}.
-	 * @throws NullPointerException
-	 *             if any of the arguments is/are {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is not in the specified
+	 *                                  range or if {@code maxValue} is less than
+	 *                                  {@code minValue}.
+	 * @throws NullPointerException     if any of the arguments is/are {@code null}.
 	 * 
 	 * @see BigDecimal
 	 */
@@ -1806,23 +1678,21 @@ public final class ObjectUtils {
 	 * less than the minimum value. An optional message can also be given to be used
 	 * as the exception message.
 	 * 
-	 * @param minValue
-	 *            the minimum value<i><strong>(inclusive)</strong></i> of the range.
-	 * @param maxValue
-	 *            the maximum value<i><strong>(exclusive)</strong></i> of the range.
-	 * @param value
-	 *            the {@code BigDecimal} to check.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param minValue the minimum value<i><strong>(inclusive)</strong></i> of the
+	 *                 range.
+	 * @param maxValue the maximum value<i><strong>(exclusive)</strong></i> of the
+	 *                 range.
+	 * @param value    the {@code BigDecimal} to check.
+	 * @param message  an optional message to be used as as the
+	 *                 {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if it is in the specified range.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is not in the specified range or if
-	 *             {@code maxValue} is less than {@code minValue}.
-	 * @throws NullPointerException
-	 *             if any of the first three arguments is/are {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is not in the specified
+	 *                                  range or if {@code maxValue} is less than
+	 *                                  {@code minValue}.
+	 * @throws NullPointerException     if any of the first three arguments is/are
+	 *                                  {@code null}.
 	 * 
 	 * @see BigDecimal
 	 */
@@ -1835,22 +1705,19 @@ public final class ObjectUtils {
 		return value;
 	}
 
-	/*
-	 * ------------------------------------ REQUIRE NON NEGATIVE
-	 * ------------------------------------
-	 */
+	// ========================================================================
+	// REQUIRE NON NEGATIVE VALIDATORS
+	// ========================================================================
 	/**
 	 * Validates that the specified {@code int} is not negative, i.e less than zero.
 	 * If {@code value} is negative, an {@code IllegalArgumentException} is thrown,
 	 * otherwise, {@code value} is returned.
 	 * 
-	 * @param value
-	 *            the {@code int} to check.
+	 * @param value the {@code int} to check.
 	 * 
 	 * @return {@code value} if it is <i><strong>NOT</strong></i> negative.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is negative.
+	 * @throws IllegalArgumentException if {@code value} is negative.
 	 */
 	public final static int requireNonNegative(int value) {
 		return requireNonNegative(value, null);
@@ -1862,16 +1729,13 @@ public final class ObjectUtils {
 	 * otherwise, {@code value} is returned. An optional message can also be passed
 	 * to be used as the {@code IllegalArgumentException} message.
 	 * 
-	 * @param value
-	 *            the {@code int} to check.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param value   the {@code int} to check.
+	 * @param message an optional message to be used as as the
+	 *                {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if it is <i><strong>NOT</strong></i> negative.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is negative
+	 * @throws IllegalArgumentException if {@code value} is negative
 	 */
 	public final static int requireNonNegative(int value, String message) {
 		if (isNegative(value))
@@ -1884,13 +1748,11 @@ public final class ObjectUtils {
 	 * zero. If {@code value} is negative, an {@code IllegalArgumentException} is
 	 * thrown, otherwise, {@code value} is returned.
 	 * 
-	 * @param value
-	 *            the {@code long} to check.
+	 * @param value the {@code long} to check.
 	 * 
 	 * @return {@code value} if it is <i><strong>NOT</strong></i> negative.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is negative.
+	 * @throws IllegalArgumentException if {@code value} is negative.
 	 */
 	public final static long requireNonNegative(long value) {
 		return requireNonNegative(value, null);
@@ -1902,16 +1764,13 @@ public final class ObjectUtils {
 	 * thrown, otherwise, {@code value} is returned. An optional message can also be
 	 * passed to be used as the {@code IllegalArgumentException} message.
 	 * 
-	 * @param value
-	 *            the {@code long} to check.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param value   the {@code long} to check.
+	 * @param message an optional message to be used as as the
+	 *                {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if it is <i><strong>NOT</strong></i> negative.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is negative
+	 * @throws IllegalArgumentException if {@code value} is negative
 	 */
 	public final static long requireNonNegative(long value, String message) {
 		if (isNegative(value))
@@ -1924,13 +1783,11 @@ public final class ObjectUtils {
 	 * zero. If {@code value} is negative, an {@code IllegalArgumentException} is
 	 * thrown, otherwise, {@code value} is returned.
 	 * 
-	 * @param value
-	 *            the {@code float} to check.
+	 * @param value the {@code float} to check.
 	 * 
 	 * @return {@code value} if it is <i><strong>NOT</strong></i> negative.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is negative.
+	 * @throws IllegalArgumentException if {@code value} is negative.
 	 */
 	public final static float requireNonNegative(float value) {
 		return requireNonNegative(value, null);
@@ -1942,16 +1799,13 @@ public final class ObjectUtils {
 	 * thrown, otherwise, {@code value} is returned. An optional message can also be
 	 * passed to be used as the {@code IllegalArgumentException} message.
 	 * 
-	 * @param value
-	 *            the {@code float} to check.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param value   the {@code float} to check.
+	 * @param message an optional message to be used as as the
+	 *                {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if it is <i><strong>NOT</strong></i> negative.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is negative
+	 * @throws IllegalArgumentException if {@code value} is negative
 	 */
 	public final static float requireNonNegative(float value, String message) {
 		if (isNegative(value))
@@ -1964,13 +1818,11 @@ public final class ObjectUtils {
 	 * zero. If {@code value} is negative, an {@code IllegalArgumentException} is
 	 * thrown, otherwise, {@code value} is returned.
 	 * 
-	 * @param value
-	 *            the {@code double} to check.
+	 * @param value the {@code double} to check.
 	 * 
 	 * @return {@code value} if it is <i><strong>NOT</strong></i> negative.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is negative.
+	 * @throws IllegalArgumentException if {@code value} is negative.
 	 */
 	public final static double requireNonNegative(double value) {
 		return requireNonNegative(value, null);
@@ -1982,16 +1834,13 @@ public final class ObjectUtils {
 	 * thrown, otherwise, {@code value} is returned. An optional message can also be
 	 * passed to be used as the {@code IllegalArgumentException} message.
 	 * 
-	 * @param value
-	 *            the {@code double} to check.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param value   the {@code double} to check.
+	 * @param message an optional message to be used as as the
+	 *                {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if it is <i><strong>NOT</strong></i> negative.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is negative
+	 * @throws IllegalArgumentException if {@code value} is negative
 	 */
 	public final static double requireNonNegative(double value, String message) {
 		if (isNegative(value))
@@ -2004,15 +1853,12 @@ public final class ObjectUtils {
 	 * than zero. If {@code value} is negative, an {@code IllegalArgumentException}
 	 * is thrown, otherwise, {@code value} is returned.
 	 * 
-	 * @param value
-	 *            the {@code BigDecimal} to check.
+	 * @param value the {@code BigDecimal} to check.
 	 * 
 	 * @return {@code value} if it is <i><strong>NOT</strong></i> negative.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is negative.
-	 * @throws NullPointerException
-	 *             if value is {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is negative.
+	 * @throws NullPointerException     if value is {@code null}.
 	 * 
 	 * @see BigDecimal
 	 */
@@ -2026,18 +1872,14 @@ public final class ObjectUtils {
 	 * is thrown, otherwise, {@code value} is returned. An optional message can also
 	 * be passed to be used as the {@code IllegalArgumentException} message.
 	 * 
-	 * @param value
-	 *            the {@code BigDecimal} to check.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param value   the {@code BigDecimal} to check.
+	 * @param message an optional message to be used as as the
+	 *                {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if it is <i><strong>NOT</strong></i> negative.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is negative
-	 * @throws NullPointerException
-	 *             if value is {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is negative
+	 * @throws NullPointerException     if value is {@code null}.
 	 * 
 	 * @see BigDecimal
 	 */
@@ -2047,25 +1889,21 @@ public final class ObjectUtils {
 		return value;
 	}
 
-	/*
-	 * ------------------------------------ REQUIRE LESS THAN
-	 * ------------------------------------
-	 */
-
+	// ========================================================================
+	// REQUIRE LESS THAN VALIDATORS
+	// ========================================================================
 	/**
 	 * Validates that an {@code int} is less than a supplied base value. Returns the
 	 * given {@code int} if it is less than the given base value, otherwise, an
 	 * {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness against.
-	 * @param value
-	 *            the value to check for smallness.
+	 * @param baseValue the value to compare for smallness against.
+	 * @param value     the value to check for smallness.
 	 * 
 	 * @return {@code value} if {@code value} is less than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2078,18 +1916,15 @@ public final class ObjectUtils {
 	 * given {@code int} if it is less than the given base value, otherwise, an
 	 * {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness against.
-	 * @param value
-	 *            the value to check for smallness.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for smallness against.
+	 * @param value     the value to check for smallness.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is less than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2105,15 +1940,13 @@ public final class ObjectUtils {
 	 * given {@code long} if it is less than the given base value, otherwise, an
 	 * {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness against.
-	 * @param value
-	 *            the value to check for smallness.
+	 * @param baseValue the value to compare for smallness against.
+	 * @param value     the value to check for smallness.
 	 * 
 	 * @return {@code value} if {@code value} is less than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2126,18 +1959,15 @@ public final class ObjectUtils {
 	 * given {@code long} if it is less than the given base value, otherwise, an
 	 * {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness against.
-	 * @param value
-	 *            the value to check for smallness.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for smallness against.
+	 * @param value     the value to check for smallness.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is less than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2153,15 +1983,13 @@ public final class ObjectUtils {
 	 * the given {@code float} if it is less than the given base value, otherwise,
 	 * an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness against.
-	 * @param value
-	 *            the value to check for smallness.
+	 * @param baseValue the value to compare for smallness against.
+	 * @param value     the value to check for smallness.
 	 * 
 	 * @return {@code value} if {@code value} is less than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2174,18 +2002,15 @@ public final class ObjectUtils {
 	 * the given {@code float} if it is less than the given base value, otherwise,
 	 * an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness against.
-	 * @param value
-	 *            the value to check for smallness.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for smallness against.
+	 * @param value     the value to check for smallness.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is less than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2201,15 +2026,13 @@ public final class ObjectUtils {
 	 * the given {@code long} if it is less than the given base value, otherwise, an
 	 * {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness against.
-	 * @param value
-	 *            the value to check for smallness.
+	 * @param baseValue the value to compare for smallness against.
+	 * @param value     the value to check for smallness.
 	 * 
 	 * @return {@code value} if {@code value} is less than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2222,18 +2045,15 @@ public final class ObjectUtils {
 	 * the given {@code double} if it is less than the given base value, otherwise,
 	 * an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness against.
-	 * @param value
-	 *            the value to check for smallness.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for smallness against.
+	 * @param value     the value to check for smallness.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is less than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2249,17 +2069,15 @@ public final class ObjectUtils {
 	 * Returns the given {@code BigDecimal} if it is less than the given base value,
 	 * otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness against.
-	 * @param value
-	 *            the value to check for smallness.
+	 * @param baseValue the value to compare for smallness against.
+	 * @param value     the value to check for smallness.
 	 * 
 	 * @return {@code value} if {@code value} is less than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
-	 * @throws NullPointerException
-	 *             if {@code baseValue} or/and {@code value} is/are {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
+	 * @throws NullPointerException     if {@code baseValue} or/and {@code value}
+	 *                                  is/are {@code null}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2272,20 +2090,17 @@ public final class ObjectUtils {
 	 * Returns the given {@code BigDecimal} if it is less than the given base value,
 	 * otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness against.
-	 * @param value
-	 *            the value to check for smallness.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for smallness against.
+	 * @param value     the value to check for smallness.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is less than {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
-	 * @throws NullPointerException
-	 *             if {@code baseValue} or/and {@code value} is/are {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
+	 * @throws NullPointerException     if {@code baseValue} or/and {@code value}
+	 *                                  is/are {@code null}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2296,26 +2111,22 @@ public final class ObjectUtils {
 		return value;
 	}
 
-	/*
-	 * ------------------------------------ REQUIRE LESS THAN OR EQUAL TO
-	 * ------------------------------------
-	 */
-
+	// ========================================================================
+	// REQUIRE LESS THAN OR EQUAL TO VALIDATORS
+	// ========================================================================
 	/**
 	 * Validates that an {@code int} is less than or equal to a supplied base value.
 	 * Returns the given {@code int} if it is less than or equal to the given base
 	 * value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness or equality against.
-	 * @param value
-	 *            the value to check for smallness or equality.
+	 * @param baseValue the value to compare for smallness or equality against.
+	 * @param value     the value to check for smallness or equality.
 	 * 
 	 * @return {@code value} if {@code value} is less than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2328,19 +2139,16 @@ public final class ObjectUtils {
 	 * Returns the given {@code int} if it is less than or equal to the given base
 	 * value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness or equality against.
-	 * @param value
-	 *            the value to check for smallness or equality.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for smallness or equality against.
+	 * @param value     the value to check for smallness or equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is less than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2356,16 +2164,14 @@ public final class ObjectUtils {
 	 * Returns the given {@code long} if it is less than or equal to the given base
 	 * value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness or equality against.
-	 * @param value
-	 *            the value to check for smallness or equality.
+	 * @param baseValue the value to compare for smallness or equality against.
+	 * @param value     the value to check for smallness or equality.
 	 * 
 	 * @return {@code value} if {@code value} is less than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2378,19 +2184,16 @@ public final class ObjectUtils {
 	 * Returns the given {@code long} if it is less than or equal to the given base
 	 * value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness or equality against.
-	 * @param value
-	 *            the value to check for smallness or equality.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for smallness or equality against.
+	 * @param value     the value to check for smallness or equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is less than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2406,16 +2209,14 @@ public final class ObjectUtils {
 	 * value. Returns the given {@code float} if it is less than or equal to the
 	 * given base value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness or equality against.
-	 * @param value
-	 *            the value to check for smallness or equality.
+	 * @param baseValue the value to compare for smallness or equality against.
+	 * @param value     the value to check for smallness or equality.
 	 * 
 	 * @return {@code value} if {@code value} is less than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2428,19 +2229,16 @@ public final class ObjectUtils {
 	 * value. Returns the given {@code float} if it is less than or equal to the
 	 * given base value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness or equality against.
-	 * @param value
-	 *            the value to check for smallness or equality.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for smallness or equality against.
+	 * @param value     the value to check for smallness or equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is less than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2456,16 +2254,14 @@ public final class ObjectUtils {
 	 * value. Returns the given {@code double} if it is less than or equal to the
 	 * given base value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness or equality against.
-	 * @param value
-	 *            the value to check for smallness or equality.
+	 * @param baseValue the value to compare for smallness or equality against.
+	 * @param value     the value to check for smallness or equality.
 	 * 
 	 * @return {@code value} if {@code value} is less than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2478,19 +2274,16 @@ public final class ObjectUtils {
 	 * value. Returns the given {@code double} if it is less than or equal to the
 	 * given base value, otherwise, an {@code IllegalArgumentException} is thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness or equality against.
-	 * @param value
-	 *            the value to check for smallness or equality.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for smallness or equality against.
+	 * @param value     the value to check for smallness or equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is less than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2507,18 +2300,16 @@ public final class ObjectUtils {
 	 * the given base value, otherwise, an {@code IllegalArgumentException} is
 	 * thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness or equality against.
-	 * @param value
-	 *            the value to check for smallness or equality.
+	 * @param baseValue the value to compare for smallness or equality against.
+	 * @param value     the value to check for smallness or equality.
 	 * 
 	 * @return {@code value} if {@code value} is less than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
-	 * @throws NullPointerException
-	 *             if {@code baseValue} or/and {@code value} is/are {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
+	 * @throws NullPointerException     if {@code baseValue} or/and {@code value}
+	 *                                  is/are {@code null}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2532,21 +2323,18 @@ public final class ObjectUtils {
 	 * the given base value, otherwise, an {@code IllegalArgumentException} is
 	 * thrown.
 	 * 
-	 * @param baseValue
-	 *            the value to compare for smallness or equality against.
-	 * @param value
-	 *            the value to check for smallness or equality.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param baseValue the value to compare for smallness or equality against.
+	 * @param value     the value to check for smallness or equality.
+	 * @param message   an optional message to be used as as the
+	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is less than or equal to
 	 *         {@code baseValue}.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is greater than {@code baseValue}.
-	 * @throws NullPointerException
-	 *             if {@code baseValue} or/and {@code value} is/are {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is greater than
+	 *                                  {@code baseValue}.
+	 * @throws NullPointerException     if {@code baseValue} or/and {@code value}
+	 *                                  is/are {@code null}.
 	 * 
 	 * @since 1.1.0
 	 */
@@ -2557,27 +2345,21 @@ public final class ObjectUtils {
 		return value;
 	}
 
-	/*-------------------------------------------------------------------------------------
-	 * 
-	 * SERIALIZABLES
-	 *
-	 * ------------------------------------------------------------------------------------
-	 */
+	// ========================================================================
+	// SERIALIZABLES UTILS
+	// ========================================================================
 	/**
 	 * Checks if a given instance is serializable, i.e implements the
 	 * {@link Serializable} interface. Returns <code>true</code> if the instance is
 	 * serializable, otherwise returns <code>false</code>.
 	 * 
-	 * @param <T>
-	 *            the type of the instance to be checked for serializability
+	 * @param <T>   the type of the instance to be checked for serializability
 	 * 
-	 * @param value
-	 *            the instance to check for serializability
+	 * @param value the instance to check for serializability
 	 * @return <code>true</code> if value is serializable or <code>false</code>
 	 *         otherwise.
 	 * 
-	 * @throws NullPointerException
-	 *             if value is null.
+	 * @throws NullPointerException if value is null.
 	 * 
 	 * @see Serializable
 	 */
@@ -2594,18 +2376,14 @@ public final class ObjectUtils {
 	 * is thrown. Also a {@code NullPointerException} will also be thrown if the
 	 * supplied instance is {@code null}.
 	 * 
-	 * @param <T>
-	 *            the type of the instance to be checked for serializability.
+	 * @param <T>   the type of the instance to be checked for serializability.
 	 * 
-	 * @param value
-	 *            the instance to check for serializability.
+	 * @param value the instance to check for serializability.
 	 * 
 	 * @return {@code value} if it's not <i>null <b>AND</b> is serializable</i>.
 	 * 
-	 * @throws NullPointerException
-	 *             if {@code value} is {@code null}.
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is not serializable.
+	 * @throws NullPointerException     if {@code value} is {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is not serializable.
 	 * 
 	 * @see #requireSerializable(Object, String)
 	 * @see Serializable
@@ -2622,21 +2400,16 @@ public final class ObjectUtils {
 	 * supplied instance is {@code null}. A message can optionally be passed to be
 	 * used in the construction of the {@code IllegalArgumentException}.
 	 * 
-	 * @param <T>
-	 *            the type of the instance to be checked for serializability.
+	 * @param <T>     the type of the instance to be checked for serializability.
 	 * 
-	 * @param value
-	 *            the instance to check for serializability.
-	 * @param message
-	 *            an optional message to be used as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param value   the instance to check for serializability.
+	 * @param message an optional message to be used as the
+	 *                {@code IllegalArgumentException} message.
 	 * 
 	 * @return value if it's not <i>null <b>AND</b> is serializable</i>.
 	 * 
-	 * @throws NullPointerException
-	 *             if {@code value} is {@code null}.
-	 * @throws IllegalArgumentException
-	 *             if {@code value} is not serializable.
+	 * @throws NullPointerException     if {@code value} is {@code null}.
+	 * @throws IllegalArgumentException if {@code value} is not serializable.
 	 * 
 	 * @see Serializable
 	 */
@@ -2646,12 +2419,9 @@ public final class ObjectUtils {
 		return value;
 	}
 
-	/*-------------------------------------------------------------------------------------
-	 * 
-	 * STRINGS
-	 *
-	 * ------------------------------------------------------------------------------------
-	 */
+	// ========================================================================
+	// STRINGS UTILS
+	// ========================================================================
 	/**
 	 * Checks that the given <code>String</code> has characters between the given
 	 * minimum chars (inclusive) and the given maximum chars (exclusive). Returns
@@ -2665,22 +2435,18 @@ public final class ObjectUtils {
 	 * <li><code>maxChars</code> is equal to <code>minChars</code></li>
 	 * </ul>
 	 * 
-	 * @param minChars
-	 *            the minimum number of characters (inclusive) that the given
-	 *            <code>String</code> should have.
-	 * @param maxChars
-	 *            the maximum number of characters (exclusive) that the given
-	 *            <code>String</code> should have.
-	 * @param value
-	 *            the <code>String</code> to check.
+	 * @param minChars the minimum number of characters (inclusive) that the given
+	 *                 <code>String</code> should have.
+	 * @param maxChars the maximum number of characters (exclusive) that the given
+	 *                 <code>String</code> should have.
+	 * @param value    the <code>String</code> to check.
 	 * 
 	 * @return <code>true</code> if the given <code>String</code>'s length falls
 	 *         within the specified range, <code>false</code> otherwise.
 	 * 
-	 * @throws NullPointerException
-	 *             if <code>value</code> is <code>null</code>.
-	 * @throws IllegalArgumentException
-	 *             if any of the conditions stated above are/is met.
+	 * @throws NullPointerException     if <code>value</code> is <code>null</code>.
+	 * @throws IllegalArgumentException if any of the conditions stated above are/is
+	 *                                  met.
 	 */
 	public final static boolean hasCharsInRange(int minChars, int maxChars, String value) {
 		requireGreaterThan(requireNonNegative(minChars), requireNonNegative(maxChars),
@@ -2696,17 +2462,14 @@ public final class ObjectUtils {
 	 * {@link IllegalArgumentException} will be thrown if <code>maxChars</code> is
 	 * negative.
 	 * 
-	 * @param maxChars
-	 *            the maximum number of characters (exclusive) that the given
-	 *            <code>String</code> should have.
-	 * @param value
-	 *            the <code>String</code> to check.
+	 * @param maxChars the maximum number of characters (exclusive) that the given
+	 *                 <code>String</code> should have.
+	 * @param value    the <code>String</code> to check.
 	 * 
 	 * @return <code>true</code> if the given <code>String</code>'s length is less
 	 *         than <code>maxChars</code>, <code>false</code> otherwise.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if <code>maxChars</code> is negative.
+	 * @throws IllegalArgumentException if <code>maxChars</code> is negative.
 	 */
 	public final static boolean hasLessThanChars(int maxChars, String value) {
 		return requireNonNull(value).length() < requireNonNegative(maxChars);
@@ -2720,18 +2483,15 @@ public final class ObjectUtils {
 	 * {@link IllegalArgumentException} will be thrown if <code>minChars</code> is
 	 * negative.
 	 * 
-	 * @param minChars
-	 *            the minimum number of characters (inclusive) that the given
-	 *            <code>String</code> should have.
-	 * @param value
-	 *            the <code>String</code> to check.
+	 * @param minChars the minimum number of characters (inclusive) that the given
+	 *                 <code>String</code> should have.
+	 * @param value    the <code>String</code> to check.
 	 * 
 	 * @return <code>true</code> if the given <code>String</code>'s length is
 	 *         greater than or equal to <code>minChars</code>, <code>false</code>
 	 *         otherwise.
 	 * 
-	 * @throws IllegalArgumentException
-	 *             if <code>minChars</code> is negative.
+	 * @throws IllegalArgumentException if <code>minChars</code> is negative.
 	 */
 	public final static boolean hasMoreThanChars(int minChars, String value) {
 		return isGreaterThanOrEqualTo(requireNonNegative(minChars), requireNonNull(value).length());
@@ -2748,24 +2508,20 @@ public final class ObjectUtils {
 	 * {@code IllegalArgumentException} might be thrown if any of that methods
 	 * requirements are not met.</i>
 	 * 
-	 * @param minChars
-	 *            the minimum number of characters
-	 *            <i><strong>(inclusive)</strong></i> that the given {@code String}
-	 *            should have.
-	 * @param maxChars
-	 *            the maximum number of characters
-	 *            <i><strong>(exclusive)</strong></i> that the given {@code String}
-	 *            should have.
-	 * @param value
-	 *            the {@code String} to check.
+	 * @param minChars the minimum number of characters
+	 *                 <i><strong>(inclusive)</strong></i> that the given
+	 *                 {@code String} should have.
+	 * @param maxChars the maximum number of characters
+	 *                 <i><strong>(exclusive)</strong></i> that the given
+	 *                 {@code String} should have.
+	 * @param value    the {@code String} to check.
 	 * 
 	 * @return {@code value} if {@code value}'s length falls within the specified
 	 *         range.
 	 * 
-	 * @throws NullPointerException
-	 *             if {@code value} is {@code null}.
-	 * @throws IllegalArgumentException
-	 *             if any of the conditions stated above are/is met.
+	 * @throws NullPointerException     if {@code value} is {@code null}.
+	 * @throws IllegalArgumentException if any of the conditions stated above are/is
+	 *                                  met.
 	 * 
 	 * @see #hasCharsInRange(int, int, String)
 	 */
@@ -2787,27 +2543,22 @@ public final class ObjectUtils {
 	 * {@code IllegalArgumentException} might be thrown if any of that methods
 	 * requirements are not met.</i>
 	 * 
-	 * @param minChars
-	 *            the minimum number of characters
-	 *            <i><strong>(inclusive)</strong></i> that the given {@code String}
-	 *            should have.
-	 * @param maxChars
-	 *            the maximum number of characters
-	 *            <i><strong>(exclusive)</strong></i> that the given {@code String}
-	 *            should have.
-	 * @param value
-	 *            the {@code String} to check.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param minChars the minimum number of characters
+	 *                 <i><strong>(inclusive)</strong></i> that the given
+	 *                 {@code String} should have.
+	 * @param maxChars the maximum number of characters
+	 *                 <i><strong>(exclusive)</strong></i> that the given
+	 *                 {@code String} should have.
+	 * @param value    the {@code String} to check.
+	 * @param message  an optional message to be used as as the
+	 *                 {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value}'s length falls within the specified
 	 *         range.
 	 * 
-	 * @throws NullPointerException
-	 *             if {@code value} is {@code null}.
-	 * @throws IllegalArgumentException
-	 *             if any of the conditions stated above are/is met.
+	 * @throws NullPointerException     if {@code value} is {@code null}.
+	 * @throws IllegalArgumentException if any of the conditions stated above are/is
+	 *                                  met.
 	 * 
 	 * @see #hasCharsInRange(int, int, String)
 	 */
@@ -2831,20 +2582,17 @@ public final class ObjectUtils {
 	 * {@code IllegalArgumentException}might be thrown if any of that methods
 	 * requirements are not met.</i>
 	 * 
-	 * @param maxChars
-	 *            the maximum number of characters
-	 *            <i><strong>(exclusive)</strong></i> that the given {@code String}
-	 *            should have.
-	 * @param value
-	 *            the {@code String} to check.
+	 * @param maxChars the maximum number of characters
+	 *                 <i><strong>(exclusive)</strong></i> that the given
+	 *                 {@code String} should have.
+	 * @param value    the {@code String} to check.
 	 * 
 	 * @return {@code value} if {@code value}'s length is less than
 	 *         {@code maxChars}.
 	 * 
-	 * @throws NullPointerException
-	 *             if {@code value} is {@code null}.
-	 * @throws IllegalArgumentException
-	 *             if any of the conditions stated above are/is met.
+	 * @throws NullPointerException     if {@code value} is {@code null}.
+	 * @throws IllegalArgumentException if any of the conditions stated above are/is
+	 *                                  met.
 	 * 
 	 * @see #hasLessThanChars(int, String)
 	 */
@@ -2865,23 +2613,19 @@ public final class ObjectUtils {
 	 * {@code IllegalArgumentException}might be thrown if any of that methods
 	 * requirements are not met.</i>
 	 * 
-	 * @param maxChars
-	 *            the maximum number of characters
-	 *            <i><strong>(exclusive)</strong></i> that the given {@code String}
-	 *            should have.
-	 * @param value
-	 *            the {@code String} to check.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param maxChars the maximum number of characters
+	 *                 <i><strong>(exclusive)</strong></i> that the given
+	 *                 {@code String} should have.
+	 * @param value    the {@code String} to check.
+	 * @param message  an optional message to be used as as the
+	 *                 {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value}'s length is less than
 	 *         {@code maxChars}.
 	 * 
-	 * @throws NullPointerException
-	 *             if {@code value} is {@code null}.
-	 * @throws IllegalArgumentException
-	 *             if any of the conditions stated above are/is met.
+	 * @throws NullPointerException     if {@code value} is {@code null}.
+	 * @throws IllegalArgumentException if any of the conditions stated above are/is
+	 *                                  met.
 	 * 
 	 * @see #hasLessThanChars(int, String)
 	 */
@@ -2904,20 +2648,17 @@ public final class ObjectUtils {
 	 * {@code IllegalArgumentException}might be thrown if any of that methods
 	 * requirements are not met.</i>
 	 * 
-	 * @param minChars
-	 *            the minimum number of characters
-	 *            <i><strong>(inclusive)</strong></i> that the given {@code String}
-	 *            should have.
-	 * @param value
-	 *            the {@code String} to check.
+	 * @param minChars the minimum number of characters
+	 *                 <i><strong>(inclusive)</strong></i> that the given
+	 *                 {@code String} should have.
+	 * @param value    the {@code String} to check.
 	 * 
 	 * @return {@code value} if {@code value}'s length is greater than or equal to
 	 *         {@code minChars}.
 	 * 
-	 * @throws NullPointerException
-	 *             if {@code value} is {@code null}.
-	 * @throws IllegalArgumentException
-	 *             if any of the conditions stated above are/is met.
+	 * @throws NullPointerException     if {@code value} is {@code null}.
+	 * @throws IllegalArgumentException if any of the conditions stated above are/is
+	 *                                  met.
 	 * 
 	 * @see #hasMoreThanChars(int, String)
 	 */
@@ -2939,23 +2680,19 @@ public final class ObjectUtils {
 	 * {@code IllegalArgumentException}might be thrown if any of that methods
 	 * requirements are not met.</i>
 	 * 
-	 * @param minChars
-	 *            the minimum number of characters
-	 *            <i><strong>(inclusive)</strong></i> that the given {@code String}
-	 *            should have.
-	 * @param value
-	 *            the {@code String} to check.
-	 * @param message
-	 *            an optional message to be used as as the
-	 *            {@code IllegalArgumentException} message.
+	 * @param minChars the minimum number of characters
+	 *                 <i><strong>(inclusive)</strong></i> that the given
+	 *                 {@code String} should have.
+	 * @param value    the {@code String} to check.
+	 * @param message  an optional message to be used as as the
+	 *                 {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value}'s length is greater than or equal to
 	 *         {@code minChars}.
 	 * 
-	 * @throws NullPointerException
-	 *             if {@code value} is {@code null}.
-	 * @throws IllegalArgumentException
-	 *             if any of the conditions stated above are/is met.
+	 * @throws NullPointerException     if {@code value} is {@code null}.
+	 * @throws IllegalArgumentException if any of the conditions stated above are/is
+	 *                                  met.
 	 * 
 	 * @see #hasMoreThanChars(int, String)
 	 */
@@ -2976,15 +2713,13 @@ public final class ObjectUtils {
 	 * {@link #requireNonEmptyString(String, String) requireNonEmptyString(value,
 	 * null)}.
 	 * 
-	 * @param value
-	 *            the {@code String} to be checked for validity.
+	 * @param value the {@code String} to be checked for validity.
 	 *
 	 * @return value if it's not <i>null <b>AND/OR</b> empty</i>.
 	 * 
-	 * @throws NullPointerException
-	 *             if value is null.
-	 * @throws IllegalArgumentException
-	 *             if value is empty<i>(has a length of zero)</i>.
+	 * @throws NullPointerException     if value is null.
+	 * @throws IllegalArgumentException if value is empty<i>(has a length of
+	 *                                  zero)</i>.
 	 * 
 	 * @see #requireNonEmptyString(String, String)
 	 */
@@ -3020,18 +2755,15 @@ public final class ObjectUtils {
 	 * 		<i>"value cannot be empty"</i>
 	 * </pre>
 	 * 
-	 * @param value
-	 *            the {@code String} to be checked for validity.
-	 * @param name
-	 *            the name of the {@code String} variable to be checked for
-	 *            validity.
+	 * @param value the {@code String} to be checked for validity.
+	 * @param name  the name of the {@code String} variable to be checked for
+	 *              validity.
 	 *
 	 * @return value if it's not <i>null <b>AND/OR</b> empty</i>.
 	 * 
-	 * @throws NullPointerException
-	 *             if value is null.
-	 * @throws IllegalArgumentException
-	 *             if value is empty<i>(has a length of zero)</i>.
+	 * @throws NullPointerException     if value is null.
+	 * @throws IllegalArgumentException if value is empty<i>(has a length of
+	 *                                  zero)</i>.
 	 * 
 	 * @see #requireNonEmptyString(String, String, String)
 	 */
@@ -3048,20 +2780,16 @@ public final class ObjectUtils {
 	 * as the second and third arguments to be used in the construction of
 	 * exceptions.
 	 * 
-	 * @param value
-	 *            the {@code String} to be checked for validity.
-	 * @param nullMessage
-	 *            an optional message to be used when raising the
-	 *            {@code NullPointerException}.
-	 * @param emptyMessage
-	 *            an optional message to be used when raising the
-	 *            {@code IllegalArgumentException}.
+	 * @param value        the {@code String} to be checked for validity.
+	 * @param nullMessage  an optional message to be used when raising the
+	 *                     {@code NullPointerException}.
+	 * @param emptyMessage an optional message to be used when raising the
+	 *                     {@code IllegalArgumentException}.
 	 * @return value if it's not <i>null <b>AND/OR</b> empty</i>.
 	 * 
-	 * @throws NullPointerException
-	 *             if value is null.
-	 * @throws IllegalArgumentException
-	 *             if value is empty<i>(has a length of zero)</i>.
+	 * @throws NullPointerException     if value is null.
+	 * @throws IllegalArgumentException if value is empty<i>(has a length of
+	 *                                  zero)</i>.
 	 */
 	public static final String requireNonEmptyString(String value, String nullMessage, String emptyMessage) {
 		// Check if messages are null and set defaults
@@ -3072,6 +2800,7 @@ public final class ObjectUtils {
 		return value;
 	}
 
+	// private constructor to prevent initialization
 	private ObjectUtils() {
 	}
 }

--- a/src/main/java/com/kori_47/utils/ObjectUtils.java
+++ b/src/main/java/com/kori_47/utils/ObjectUtils.java
@@ -61,6 +61,95 @@ public final class ObjectUtils {
 	 * ------------------------------------------------------------------------------------
 	 */
 	/*
+	 * ------------------------------------ IS EQUAL
+	 * ------------------------------------
+	 */
+	/**
+	 * Checks if an {@code int} is equal to a supplied base value. Returns {@code true} if the
+	 * given {@code int} is equal to the supplied base value.
+	 * 
+	 * @param baseValue the value to compare for equality to.
+	 * @param value the value to check for equality.
+	 * @return {@code true} if {@code value} is equal to {@code baseValue}.
+	 * 
+	 * @since 1.2.0
+	 */
+	public final static boolean isEqualTo(int baseValue, int value) {
+		return baseValue == value;
+	}
+
+	/**
+	 * Checks if a {@code long} is equal to a supplied base value. Returns {@code true} if the
+	 * given {@code long} is equal to the supplied base value.
+	 * 
+	 * @param baseValue the value to compare for equality to.
+	 * @param value the value to check for equality.
+	 * @return {@code true} if {@code value} is equal to {@code baseValue}.
+	 * 
+	 * @since 1.2.0
+	 */
+	public final static boolean isEqualTo(long baseValue, long value) {
+		return baseValue == value;
+	}
+	
+	/**
+	 * Checks if a {@code float} is equal to a supplied base value. Returns
+	 * {@code true} if the given {@code float} is equal to the supplied base
+	 * value.<br>
+	 * <br>
+	 * <i> <strong>NOTE:</strong> This method uses
+	 * {@link Float#compare(float, float)} to compare the given values. </i>
+	 * 
+	 * @param baseValue the value to compare for equality to.
+	 * @param value the value to check for equality.
+	 * 
+	 * @return {@code true} if {@code value} is equal to {@code baseValue}.
+	 * 
+	 * @since 1.2.0
+	 */
+	public final static boolean isEqualTo(float baseValue, float value) {
+		return Float.compare(value, baseValue) == 0;
+	}
+
+	/**
+	 * Checks if a {@code double} is equal to a supplied base value. Returns
+	 * {@code true} if the given {@code double} is equal to the supplied base
+	 * value. <br>
+	 * <br>
+	 * <i> <strong>NOTE:</strong> This method uses
+	 * {@link Double#compare(double, double)} to compare the given values. </i>
+	 * 
+	 * @param baseValue the value to compare for equality to.
+	 * @param value the value to check for equality.
+	 * 
+	 * @return {@code true} if {@code value} is equal to {@code baseValue}.
+	 * 
+	 * @since 1.2.0
+	 */
+	public final static boolean isEqualTo(double baseValue, double value) {
+		return Double.compare(value, baseValue) == 0;
+	}
+
+	/**
+	 * Checks if a {@link BigDecimal} is equal to a supplied base value. Returns
+	 * {@code true} if the given {@code BigDecimal} is equal to the supplied
+	 * base value.
+	 * 
+	 * @param baseValue the value to compare for equality to.
+	 * @param value the value to check for equality.
+	 * 
+	 * @return {@code true} if {@code value} is greater than {@code baseValue}.
+	 * 
+	 * @throws NullPointerException if any of the two arguments is/are {@code null}.
+	 *
+	 * @since 1.2.0
+	 */
+	public final static boolean isEqualTo(BigDecimal baseValue, BigDecimal value) {
+		return requireNonNull(value, "value cannot be null.")
+				.compareTo(requireNonNull(baseValue, "baseValue cannot be null.")) == 0;
+	}
+
+	/*
 	 * ------------------------------------ IS GREATER THAN
 	 * ------------------------------------
 	 */

--- a/src/main/java/com/kori_47/utils/ObjectUtils.java
+++ b/src/main/java/com/kori_47/utils/ObjectUtils.java
@@ -795,6 +795,214 @@ public final class ObjectUtils {
 	}
 
 	/*
+	 * ------------------------------------ REQUIRE EQUAL TO
+	 * ------------------------------------
+	 */
+
+	/**
+	 * Validates that an {@code int} is equal to a supplied base value. Returns
+	 * the given {@code int} if it is equal to the given base value, otherwise,
+	 * an {@code IllegalArgumentException} is thrown.
+	 * 
+	 * @param baseValue the value to compare for equality to.
+	 * @param value the value to check for equality.
+	 * 
+	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
+	 * 
+	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * 
+	 * @since 1.2.0
+	 */
+	public final static int requireEqualTo(int baseValue, int value) {
+		return requireEqualTo(baseValue, value, null);
+	}
+
+	/**
+	 * Validates that an {@code int} is equal to a supplied base value. Returns
+	 * the given {@code int} if it is equal to the given base value, otherwise,
+	 * an {@code IllegalArgumentException} is thrown.
+	 * 
+	 * @param baseValue the value to compare for equality to.
+	 * @param value the value to check for equality.
+	 * @param message an optional message to be used as as the {@code IllegalArgumentException} message.
+	 * 
+	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
+	 * 
+	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * 
+	 * @since 1.2.0
+	 */
+	public final static int requireEqualTo(int baseValue, int value, String message) {
+		if (!isEqualTo(baseValue, value))
+			throw new IllegalArgumentException((nonNull(message) ? message
+					: String.format("value(%d) should be equal to %d.", value, baseValue)));
+		return value;
+	}
+
+	/**
+	 * Validates that a {@code long} is equal to a supplied base value. Returns
+	 * the given {@code long} if it is equal to the given base value, otherwise,
+	 * an {@code IllegalArgumentException} is thrown.
+	 * 
+	 * @param baseValue the value to compare for equality to.
+	 * @param value the value to check for equality.
+	 * 
+	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
+	 * 
+	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * 
+	 * @since 1.2.0
+	 */
+	public final static long requireEqualTo(long baseValue, long value) {
+		return requireEqualTo(baseValue, value, null);
+	}
+
+	/**
+	 * Validates that a {@code long} is equal to a supplied base value. Returns
+	 * the given {@code long} if it is equal to the given base value, otherwise,
+	 * an {@code IllegalArgumentException} is thrown.
+	 * 
+	 * @param baseValue the value to compare for equality to.
+	 * @param value the value to check for equality.
+	 * @param message an optional message to be used as as the {@code IllegalArgumentException} message.
+	 * 
+	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
+	 * 
+	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * 
+	 * @since 1.2.0
+	 */
+	public final static long requireEqualTo(long baseValue, long value, String message) {
+		if (!isEqualTo(baseValue, value))
+			throw new IllegalArgumentException((nonNull(message) ? message
+					: String.format("value(%d) should be equal to %d.", value, baseValue)));
+		return value;
+	}
+
+	/**
+	 * Validates that a {@code long} is equal to a supplied base value. Returns
+	 * the given {@code long} if it is equal to the given base value, otherwise,
+	 * an {@code IllegalArgumentException} is thrown.
+	 * 
+	 * @param baseValue the value to compare for equality to.
+	 * @param value the value to check for equality.
+	 * 
+	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
+	 * 
+	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * 
+	 * @since 1.2.0
+	 */
+	public final static float requireEqualTo(float baseValue, float value) {
+		return requireEqualTo(baseValue, value, null);
+	}
+
+	/**
+	 * Validates that a {@code float} is equal to a supplied base value. Returns
+	 * the given {@code float} if it is equal to the given base value, otherwise,
+	 * an {@code IllegalArgumentException} is thrown.
+	 * 
+	 * @param baseValue the value to compare for equality to.
+	 * @param value the value to check for equality.
+	 * @param message an optional message to be used as as the {@code IllegalArgumentException} message.
+	 * 
+	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
+	 * 
+	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * 
+	 * @since 1.2.0
+	 */
+	public final static float requireEqualTo(float baseValue, float value, String message) {
+		if (!isEqualTo(baseValue, value))
+			throw new IllegalArgumentException((nonNull(message) ? message
+					: String.format("value(%f) should be equal to %f.", value, baseValue)));
+		return value;
+	}
+
+	/**
+	 * Validates that a {@code double} is equal to a supplied base value. Returns
+	 * the given {@code double} if it is equal to the given base value, otherwise,
+	 * an {@code IllegalArgumentException} is thrown.
+	 * 
+	 * @param baseValue the value to compare for equality to.
+	 * @param value the value to check for equality.
+	 * 
+	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
+	 * 
+	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * 
+	 * @since 1.2.0
+	 */
+	public final static double requireEqualTo(double baseValue, double value) {
+		return requireEqualTo(baseValue, value, null);
+	}
+
+	/**
+	 * Validates that a {@code double} is equal to a supplied base value. Returns
+	 * the given {@code double} if it is equal to the given base value, otherwise,
+	 * an {@code IllegalArgumentException} is thrown.
+	 * 
+	 * @param baseValue the value to compare for equality to.
+	 * @param value the value to check for equality.
+	 * @param message an optional message to be used as as the {@code IllegalArgumentException} message.
+	 * 
+	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
+	 * 
+	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * 
+	 * @since 1.2.0
+	 */
+	public final static double requireEqualTo(double baseValue, double value, String message) {
+		if (!isEqualTo(baseValue, value))
+			throw new IllegalArgumentException((nonNull(message) ? message
+					: String.format("value(%f) should be equal to %f.", value, baseValue)));
+		return value;
+	}
+
+	/**
+	 * Validates that a {@link BigDecimal} is equal to a supplied base value. Returns
+	 * the given {@code BigDecimal} if it is equal to the given base value, otherwise,
+	 * an {@code IllegalArgumentException} is thrown.
+	 * 
+	 * @param baseValue the value to compare for equality to.
+	 * @param value the value to check for equality.
+	 * @param message an optional message to be used as as the {@code IllegalArgumentException} message.
+	 * 
+	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
+	 * 
+	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * @throws NullPointerException if {@code baseValue} or/and {@code value} is/are {@code null}.
+	 * 
+	 * @since 1.2.0
+	 */
+	public final static BigDecimal requireEqualTo(BigDecimal baseValue, BigDecimal value) {
+		return requireEqualTo(baseValue, value, null);
+	}
+
+	/**
+	 * Validates that a {@link BigDecimal} is equal to a supplied base value. Returns
+	 * the given {@code BigDecimal} if it is equal to the given base value, otherwise,
+	 * an {@code IllegalArgumentException} is thrown.
+	 * 
+	 * @param baseValue the value to compare for equality to.
+	 * @param value the value to check for equality.
+	 * @param message an optional message to be used as as the {@code IllegalArgumentException} message.
+	 * 
+	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
+	 * 
+	 * @throws IllegalArgumentException if {@code value} is not equal to {@code baseValue}.
+	 * @throws NullPointerException if {@code baseValue} or/and {@code value} is/are {@code null}.
+	 * 
+	 * @since 1.2.0
+	 */
+	public final static BigDecimal requireEqualTo(BigDecimal baseValue, BigDecimal value, String message) {
+		if (!isEqualTo(baseValue, value))
+			throw new IllegalArgumentException((nonNull(message) ? message
+					: String.format("value(%s) should be equal to %s.", value, baseValue)));
+		return value;
+	}
+
+	/*
 	 * ------------------------------------ REQUIRE GREATER THAN
 	 * ------------------------------------
 	 */

--- a/src/main/java/com/kori_47/utils/ObjectUtils.java
+++ b/src/main/java/com/kori_47/utils/ObjectUtils.java
@@ -901,8 +901,6 @@ public final class ObjectUtils {
 	 * 
 	 * @param baseValue the value to compare for equality to.
 	 * @param value     the value to check for equality.
-	 * @param message   an optional message to be used as as the
-	 *                  {@code IllegalArgumentException} message.
 	 * 
 	 * @return {@code value} if {@code value} is equal to {@code baseValue}.
 	 * 

--- a/src/test/java/com/kori_47/utils/ObjectUtilsTest.java
+++ b/src/test/java/com/kori_47/utils/ObjectUtilsTest.java
@@ -15,6 +15,28 @@ public class ObjectUtilsTest {
 	 * ------------------------------------------------------------------------------------
 	 */
 	@Test
+	public void testIsEqualTo() {
+		// Test returns true when number is equal to
+		assertTrue(ObjectUtils.isEqualTo(0, -0));
+		assertTrue(ObjectUtils.isEqualTo(-435L, -435L));
+		assertTrue(ObjectUtils.isEqualTo(-65.78724913F, -65.78724913F));
+		assertTrue(ObjectUtils.isEqualTo(0.000000000000001D, 0.000000000000001D));
+		assertTrue(ObjectUtils.isEqualTo(new BigDecimal("7"), new BigDecimal("7")));
+
+		// Test returns false when number is not equal to
+		assertFalse(ObjectUtils.isEqualTo(0, -1));
+		assertFalse(ObjectUtils.isEqualTo(435L, -435L));
+		assertFalse(ObjectUtils.isEqualTo(65.78724913F, -65.78724913F));
+		assertFalse(ObjectUtils.isEqualTo(0.999999999999999D, 0.1D));
+		assertFalse(ObjectUtils.isEqualTo(new BigDecimal("0.9999999999999999"), new BigDecimal("1")));
+
+		// Test that NullPointerException is thrown when null is given
+		assertThrows(NullPointerException.class, () -> ObjectUtils.isEqualTo(null, null));
+		assertThrows(NullPointerException.class, () -> ObjectUtils.isEqualTo(null, new BigDecimal("1")));
+		assertThrows(NullPointerException.class, () -> ObjectUtils.isEqualTo(new BigDecimal("1"), null));
+	}
+	
+	@Test
 	public void testIsGreaterThan() {
 		// Test returns true when a number is greater than
 		assertTrue(ObjectUtils.isGreaterThan(0, 2));

--- a/src/test/java/com/kori_47/utils/ObjectUtilsTest.java
+++ b/src/test/java/com/kori_47/utils/ObjectUtilsTest.java
@@ -178,11 +178,47 @@ public class ObjectUtilsTest {
 	}
 
 	@Test
+	public void testRequireEqualTo() {
+		// Test returns value when equal
+		assertEquals(0, ObjectUtils.requireEqualTo(0, -0));
+		assertEquals(-47L, ObjectUtils.requireEqualTo(-47L, -47L));
+		assertEquals(-34.4535623F, ObjectUtils.requireEqualTo(-34.4535623F, -34.4535623F));
+		assertEquals(0.999999999999999999D, ObjectUtils.requireEqualTo(0.999999999999999999D, 0.999999999999999999D));
+		assertEquals(new BigDecimal("0.9999999999999999"), ObjectUtils.requireEqualTo(new BigDecimal("0.9999999999999999"), new BigDecimal("0.9999999999999999")));
+
+		// Test throws IllegalArgumentException when not equal to
+		assertThrows(IllegalArgumentException.class, () -> ObjectUtils.requireEqualTo(0, -1));
+		assertThrows(IllegalArgumentException.class, () -> ObjectUtils.requireEqualTo(78L, -3L));
+		assertThrows(IllegalArgumentException.class, () -> ObjectUtils.requireEqualTo(7.99999F, 8F));
+		assertThrows(IllegalArgumentException.class, () -> ObjectUtils.requireEqualTo(0.99999999999999D, 1));
+		assertThrows(IllegalArgumentException.class, () -> ObjectUtils.requireEqualTo(new BigDecimal("-1"), new BigDecimal("-1.00000000001")));
+
+		// Test exception message
+		final String errMessage = "value must be equal to base value."; // generic error message
+		assertEquals(errMessage,
+				assertThrows(IllegalArgumentException.class, () -> ObjectUtils.requireEqualTo(11, 123, errMessage))
+						.getMessage());
+		assertEquals(errMessage,
+				assertThrows(IllegalArgumentException.class, () -> ObjectUtils.requireEqualTo(-1L, 1L, errMessage))
+						.getMessage());
+		assertEquals(errMessage, assertThrows(IllegalArgumentException.class,
+				() -> ObjectUtils.requireEqualTo(-373234.08F, -373233.09F, errMessage)).getMessage());
+		assertEquals(errMessage,
+				assertThrows(IllegalArgumentException.class,
+						() -> ObjectUtils.requireEqualTo(6767.6767676767D, 7676.7676767676D, errMessage))
+								.getMessage());
+		assertEquals(errMessage,
+				assertThrows(IllegalArgumentException.class,
+						() -> ObjectUtils.requireEqualTo(new BigDecimal("56.74"), new BigDecimal("56.75"), errMessage))
+								.getMessage());
+	}
+
+	@Test
 	public void testRequireInRangeReturnValues() {
 		assertEquals(2, ObjectUtils.requireInRange(2, 3, 2));
-		assertEquals(223l, ObjectUtils.requireInRange(10L, 3792L, 223L));
-		assertEquals(-32.99f, ObjectUtils.requireInRange(-100.90F, 0.00F, -32.99F));
-		assertEquals(-1.788738737d, ObjectUtils.requireInRange(-1.8673763D, 1.6D, -1.788738737D));
+		assertEquals(223L, ObjectUtils.requireInRange(10L, 3792L, 223L));
+		assertEquals(-32.99F, ObjectUtils.requireInRange(-100.90F, 0.00F, -32.99F));
+		assertEquals(-1.788738737D, ObjectUtils.requireInRange(-1.8673763D, 1.6D, -1.788738737D));
 		assertEquals(new BigDecimal("45.10"),
 				ObjectUtils.requireInRange(new BigDecimal("45.09"), new BigDecimal("45.11"), new BigDecimal("45.10")));
 

--- a/src/test/java/com/kori_47/utils/ObjectUtilsTest.java
+++ b/src/test/java/com/kori_47/utils/ObjectUtilsTest.java
@@ -1,19 +1,20 @@
 package com.kori_47.utils;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
 
 import org.junit.jupiter.api.Test;
 
+
 public class ObjectUtilsTest {
-	/*-------------------------------------------------------------------------------------
-	 * 
-	 * NUMBERS
-	 *
-	 * ------------------------------------------------------------------------------------
-	 */
+	// ========================================================================
+	// NUMBERS UTILITY METHODS TESTS
+	// ========================================================================
 	@Test
 	public void testIsEqualTo() {
 		// Test returns true when number is equal to
@@ -35,7 +36,7 @@ public class ObjectUtilsTest {
 		assertThrows(NullPointerException.class, () -> ObjectUtils.isEqualTo(null, new BigDecimal("1")));
 		assertThrows(NullPointerException.class, () -> ObjectUtils.isEqualTo(new BigDecimal("1"), null));
 	}
-	
+
 	@Test
 	public void testIsGreaterThan() {
 		// Test returns true when a number is greater than
@@ -184,14 +185,16 @@ public class ObjectUtilsTest {
 		assertEquals(-47L, ObjectUtils.requireEqualTo(-47L, -47L));
 		assertEquals(-34.4535623F, ObjectUtils.requireEqualTo(-34.4535623F, -34.4535623F));
 		assertEquals(0.999999999999999999D, ObjectUtils.requireEqualTo(0.999999999999999999D, 0.999999999999999999D));
-		assertEquals(new BigDecimal("0.9999999999999999"), ObjectUtils.requireEqualTo(new BigDecimal("0.9999999999999999"), new BigDecimal("0.9999999999999999")));
+		assertEquals(new BigDecimal("0.9999999999999999"),
+				ObjectUtils.requireEqualTo(new BigDecimal("0.9999999999999999"), new BigDecimal("0.9999999999999999")));
 
 		// Test throws IllegalArgumentException when not equal to
 		assertThrows(IllegalArgumentException.class, () -> ObjectUtils.requireEqualTo(0, -1));
 		assertThrows(IllegalArgumentException.class, () -> ObjectUtils.requireEqualTo(78L, -3L));
 		assertThrows(IllegalArgumentException.class, () -> ObjectUtils.requireEqualTo(7.99999F, 8F));
 		assertThrows(IllegalArgumentException.class, () -> ObjectUtils.requireEqualTo(0.99999999999999D, 1));
-		assertThrows(IllegalArgumentException.class, () -> ObjectUtils.requireEqualTo(new BigDecimal("-1"), new BigDecimal("-1.00000000001")));
+		assertThrows(IllegalArgumentException.class,
+				() -> ObjectUtils.requireEqualTo(new BigDecimal("-1"), new BigDecimal("-1.00000000001")));
 
 		// Test exception message
 		final String errMessage = "value must be equal to base value."; // generic error message
@@ -203,10 +206,8 @@ public class ObjectUtilsTest {
 						.getMessage());
 		assertEquals(errMessage, assertThrows(IllegalArgumentException.class,
 				() -> ObjectUtils.requireEqualTo(-373234.08F, -373233.09F, errMessage)).getMessage());
-		assertEquals(errMessage,
-				assertThrows(IllegalArgumentException.class,
-						() -> ObjectUtils.requireEqualTo(6767.6767676767D, 7676.7676767676D, errMessage))
-								.getMessage());
+		assertEquals(errMessage, assertThrows(IllegalArgumentException.class,
+				() -> ObjectUtils.requireEqualTo(6767.6767676767D, 7676.7676767676D, errMessage)).getMessage());
 		assertEquals(errMessage,
 				assertThrows(IllegalArgumentException.class,
 						() -> ObjectUtils.requireEqualTo(new BigDecimal("56.74"), new BigDecimal("56.75"), errMessage))
@@ -496,12 +497,9 @@ public class ObjectUtilsTest {
 		assertEquals("given BigDecimal must not be negative.", ex5.getMessage());
 	}
 
-	/*-------------------------------------------------------------------------------------
-	 * 
-	 * SERIALIZABLES
-	 *
-	 * ------------------------------------------------------------------------------------
-	 */
+	// ========================================================================
+	// SERIALIZABLES UTILITY METHODS TESTS
+	// ========================================================================
 	@Test
 	public void testIsSerializable() {
 		assertFalse(ObjectUtils.isSerializable(new NonSerializableClass()));
@@ -531,13 +529,9 @@ public class ObjectUtilsTest {
 		assertEquals("instance must be serializable.", ex.getMessage());
 	}
 
-	/*-------------------------------------------------------------------------------------
-	 * 
-	 * STRINGS
-	 *
-	 * ------------------------------------------------------------------------------------
-	 */
-
+	// ========================================================================
+	// STRINGS UTILITY METHODS TESTS
+	// ========================================================================
 	@Test
 	public void testHasCharsInRange() {
 		assertTrue(ObjectUtils.hasCharsInRange(2, 3, "Hi")); // 2 chars


### PR DESCRIPTION
# PR For Realease v1.2.0

## Introduction

The following notes describe important changes and information about this release.

## Upgrade Instructions

For [gradle](https://gradle.org/) users, switch to version 1.2.0 by updating your `build.gradle` 
dependencies to:

```gradle
dependencies {
    api 'com.kori_47:utils:1.2.0'
    // other dependencies
}
```

For maven users, update your `pom` file to:

```xml
<dependency>
    <groupId>com.kori_47</groupId>
    <artifactId>utils</artifactId>
    <version>1.2.0</version>
    <type>pom</type>
</dependency>
```

### Compatibility Notes

This release was tested on Java 8 and is expected to work well on Java 8 and later versions. 
It may or may not work on earlier versions of Java.

This version was tested with [junit 5](https://junit.org/junit5/).

## What's New

The following static utility methods were added in these release:

* Methods for checking if a number is equal to a given base value.
* Methods for validating if a number is equal to a given base value.

The utility methods above can be divided into _checkers_ and _validators_.

### Checkers

These are methods that take a value and check if it meets a given condition and if so, 
returns `true`, else, returns `false`. These methods are:

1. *__isEqualTo__*

    This are methods that check if a number is equal to a given baseValue. These methods 
    have the following form:

    ```java
    public final static boolean isEqualTo(<type> baseValue, <type> value){ /* method body */ };
    ```

    There are five variants of the method above, where `<type>` can be one of the following: `int`, 
    `long`, `float`, `double` or `java.math.BigDecimal`.

### Validators

These are methods that take a value and validate if it meets a given condition and if so, 
returns the value, else, throws a `java.lang.IllegalArgumentException`. These methods are:

1. *__requireEqualTo__*
    
    This are methods that validate if a number is equal to a given baseValue. These methods 
    have the following form:

    ```java
    public final static <type> requireEqualTo(<type> baseValue, <type> value){ /* method body */ };
    ```

    There are five variants of the method above, where `<type>` can be one of the following: `int`, 
    `long`, `float`, `double` or `java.math.BigDecimal`.

## Reporting Problems

If you find a problem with this release, please file a bug on [GitHub Issues](https://github.com/kennedykori/JavaUtils/issues).

---
This is a minor realease