### PR TITLE
chore!: change project base package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ dependencies {
 ### Ivy
 ```xml
 <dependency org='com.kori_47' name='utils' rev='1.2.0'>
-    <artifact name='utils' ext='pom' ></artifactId>
+    <artifact name='utils' ext='pom'/>
 </dependency>
 ```
 
@@ -79,7 +79,7 @@ Import the ObjectsUtils class in your code and use it's static methods to check 
 **Example 1:**
 
 ```java
-import static com.kori_47.utils.ObjectUtils.*;
+import static io.github.kennedykori.utils.ObjectUtils.*;
 
 public class Person {
 
@@ -100,7 +100,7 @@ public class Person {
 **Example 2:**
 
 ```java
-import static com.kori_47.utils.ObjectUtils.*;
+import static io.github.kennedykori.utils.ObjectUtils.*;
 
 public class Address {
 	

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@
  * User Manual available at https://docs.gradle.org/5.6.1/userguide/java_library_plugin.html
  */
 
-project.group = "com.kori_47"
-project.version = "1.2.0"
+project.group = "io.github.kennedykori"
+project.version = "2.0.0"
 
 plugins {
     // Apply the java-library plugin to add support for Java Library
@@ -44,7 +44,7 @@ java {
 tasks.jar {
     manifest {
         attributes(mapOf(
-                "Automatic-Module-Name" to "com.kori_47.jutils",
+                "Automatic-Module-Name" to "io.github.kennedykori.utils",
                 "Implementation-Title" to project.name,
                 "Implementation-Version" to project.version))
     }

--- a/src/main/java/io/github/kennedykori/utils/ObjectUtils.java
+++ b/src/main/java/io/github/kennedykori/utils/ObjectUtils.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package com.kori_47.utils;
+package io.github.kennedykori.utils;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;

--- a/src/main/java/io/github/kennedykori/utils/package-info.java
+++ b/src/main/java/io/github/kennedykori/utils/package-info.java
@@ -5,4 +5,4 @@
  *
  * @since Sep 9, 2019, 6:24:35 PM
  */
-package com.kori_47.utils;
+package io.github.kennedykori.utils;

--- a/src/test/java/io/github/kennedykori/utils/ObjectUtilsTest.java
+++ b/src/test/java/io/github/kennedykori/utils/ObjectUtilsTest.java
@@ -1,4 +1,4 @@
-package com.kori_47.utils;
+package io.github.kennedykori.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;


### PR DESCRIPTION
Change the project base package name from `com.kori_47.utils` to `io.github.kennedykori.utils`. This will satisfy [this requirement](https://central.sonatype.org/publish/requirements/coordinates/#choose-your-coordinates) necessary to publish the project on [Maven Central](https://central.sonatype.org/).

This change addresses issue #13.

BREAKING CHANGE: change base package name from `com.kori_47.utils` to `io.github.kennedykori.utils`.

This change has been necessitated by the [shutdown of Bintray](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/). As such, the project will be migrating to Maven Central as the primary hosting platform for the project binaries. Maven Central is a more stable hosting service. Hopefully, this will result in a better and more reliable experience. 

A change of the base package name is a breaking change and will result in a new major release.

__Migrate from v1.x.x to v2.x.x__

Change the import statement as follows:

```diff
-import static com.kori_47.utils.ObjectUtils.*;
+import static io.github.kennedykori.utils.ObjectUtils.*;
```

That's it. The library API remains the same.