### PR TITLE
feat: modularize the project

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+/**
+ * Defines useful utilities for working with primitives and objects.
+ *
+ * @since 2.0.0
+ */
+module io.github.kennedykori.utils {
+    exports io.github.kennedykori.utils;
+}


### PR DESCRIPTION
Define the module `io.github.kennedykori.utils` and migrate the project to use that module. The module exports the package `io.github.kennedykori.utils` and does not require any other modules.