### PR TITLE
build: set up publishing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,15 @@
+org.gradle.console=verbose
+version=2.0.0-dev.1
+
+# ==============================================================================
+# CUSTOM PROJECT SPECIFIC PROPERTIES
+# ==============================================================================
+
+# The GitHub repository to use.
+repo.github=https\://maven.pkg.github.com/kennedykori/jutils
+# Local repository directory. This will be created relative to the Build
+# directory.
+repo.local=repos/releases
+# Set to `true` to force the use of in memory PGP keys when signing publication
+# artifacts.
+signing.inMemory=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@
 [versions]
 checker-framework-gradle-plugin = "0.6.37"
 checkstyle = "10.12.5"
+gradle-nexus-publish-plugin = "1.3.0"
 junit-jupiter = "5.10.0"
 spotless = "6.23.3"
 
@@ -12,4 +13,5 @@ junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "jun
 
 [plugins]
 checker-framework = { id = "org.checkerframework", version.ref = "checker-framework-gradle-plugin" }
+gradle-nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradle-nexus-publish-plugin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
Add publishing capabilities to the build system, allowing the library to be consumed by other users/clients. The project can be published to the following [Apache Maven](https://maven.apache.org/) repositories:

- A test repository relative to the build diretory(`build/repos/releases`).
- Maven local repository. See [here](https://maven.apache.org/repositories/local.html) for more details.
- [GitHub Packages](https://github.com/kennedykori/jutils/packages/2045860).
- [Maven Central](https://central.sonatype.com/artifact/io.github.kennedykori/utils/overview).

This is part of the project's efforts to migrate to Maven Central, as highlighted in the issue [#13](https://github.com/kennedykori/jutils/issues/13).