### PR TITLE
ci: fix invalid semantic release plugin config

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -32,16 +32,16 @@ plugins:
         - countMatches: true
           files:
             - README.md
-            - from:
-              - "<version>.*</version>"
-              - "'io.github.kennedykori:utils:.*'"
-              - '"io.github.kennedykori:utils:.*"'
-              - 'rev=".*"'
-            - to:
-              - "<version>${nextRelease.version}</version>"
-              - "'io.github.kennedykori:utils:${nextRelease.version}'"
-              - '"io.github.kennedykori:utils:${nextRelease.version}"'
-              - 'rev="${nextRelease.version}"'
+          from:
+            - "<version>.*</version>"
+            - "'io.github.kennedykori:utils:.*'"
+            - '"io.github.kennedykori:utils:.*"'
+            - 'rev=".*"'
+          to:
+            - "<version>${nextRelease.version}</version>"
+            - "'io.github.kennedykori:utils:${nextRelease.version}'"
+            - '"io.github.kennedykori:utils:${nextRelease.version}"'
+            - 'rev="${nextRelease.version}"'
           results:
             - file: README.md
               hasChanged: true


### PR DESCRIPTION
Fix invalid config for the `semantic-release-replace-plugin` semantic release plugin.