### PR TITLE
ci: change prerelease versions suffix to rc

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,20 +1,25 @@
 branches:
   - main
   - name: develop
-    channel: dev
-    prerelease: dev
+    channel: rc
+    prerelease: rc
 plugins:
   - '@semantic-release/commit-analyzer'
   - - '@semantic-release/release-notes-generator'
     - linkCompare: true
       linkReferences: true
       writerOpts:
-        commitGroupsSort: [ type, title ]
-        commitSort: [ scope, subject ]
+        commitGroupsSort:
+          - type
+          - title
+        commitSort:
+          - scope
+          - subject
   - - semantic-release-replace-plugin
     - replacements:
         - countMatches: true
-          files: [ gradle.properties ]
+          files:
+           - gradle.properties
           from: version=.*
           to: version=${nextRelease.version}
           results:
@@ -23,7 +28,8 @@ plugins:
               numMatches: 1
               numReplacements: 1
         - countMatches: true
-          files: [ README.md ]
+          files:
+            - README.md
           from:
             - <version>.*</version>
             - "'io.github.kennedykori:utils:.*'"
@@ -42,13 +48,13 @@ plugins:
   - - '@semantic-release/changelog'
     - changelogFile: docs/CHANGELOG.md
   - - '@semantic-release/exec'
-    - publishCmd: " export GITHUB_TOKEN='${process.env.GITHUB_TOKEN}'; export ORG_GRADLE_PROJECT_signingKey='${process.env.GRADLE_SIGNING_KEY}'; export ORG_GRADLE_PROJECT_signingPassword='${process.env.GRADLE_SIGNING_PASSWORD}'; export ORG_GRADLE_PROJECT_sonatypePassword='${process.env.GRADLE_SONATYPE_PASSWORD}'; export ORG_GRADLE_PROJECT_sonatypeUsername='${process.env.GRADLE_SONATYPE_USERNAME}'; ./gradlew -Pgithub.username=kennedykori -Psigning.inMemory=true publish && ./gradlew -Pgithub.username=kennedykori -Psigning.inMemory=true findSonatypeStagingRepository closeAndReleaseSonatypeStagingRepository"
+    - publishCmd: "export GITHUB_TOKEN='${process.env.GITHUB_TOKEN}'; export ORG_GRADLE_PROJECT_signingKey='${process.env.GRADLE_SIGNING_KEY}'; export ORG_GRADLE_PROJECT_signingPassword='${process.env.GRADLE_SIGNING_PASSWORD}'; export ORG_GRADLE_PROJECT_sonatypePassword='${process.env.GRADLE_SONATYPE_PASSWORD}'; export ORG_GRADLE_PROJECT_sonatypeUsername='${process.env.GRADLE_SONATYPE_USERNAME}'; ./gradlew -Pgithub.username=kennedykori -Psigning.inMemory=true publish && ./gradlew -Pgithub.username=kennedykori -Psigning.inMemory=true findSonatypeStagingRepository closeAndReleaseSonatypeStagingRepository"
   - - '@semantic-release/git'
-    - assets: [ docs/CHANGELOG.md, gradle.properties, README.md ]
-      message: "release: ${nextRelease.version} [skip ci]
-
-
-        ${nextRelease.notes}"
+    - assets:
+        - docs/CHANGELOG.md
+        - gradle.properties
+        - README.md
+      message: "release: ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
   - - '@semantic-release/github'
     - assets:
         - path: build/libs/*.jar
@@ -59,7 +65,10 @@ tagFormat: v${version}
 #  .md#plugin-options-configuration
 # ------------------------------------------------------------------------------
 parserOptions:
-  noteKeywords: [ BREAKING CHANGE, BREAKING CHANGES, BREAKING ]
+  noteKeywords:
+    - BREAKING CHANGES
+    - BREAKING CHANGE
+    - BREAKING
 preset: conventionalcommits
 presetConfig:
   types:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,8 @@ publishing {
   publications {
     create<MavenPublication>("utils") {
       this.artifactId = artifactID
+      this.groupId = groupID
+      this.version = project.version.toString()
 
       from(components["java"])
 


### PR DESCRIPTION
This is an attempt to improve the latest version selection on [Sonatype OSS Nexus Repository](https://central.sonatype.org/publish/publish-guide/). Currently, there is no guarantee that the latest version tags will be updated on each deployment. See [this](https://support.sonatype.com/hc/en-us/articles/213464638-Why-are-the-latest-and-release-tags-in-maven-metadata-xml-not-being-updated-after-deploying-artifacts-) for details.

This is an issue since some tools and services such as [javadoc.io](https://javadoc.io/), seem to rely on these tags to select the latest version of an artifact correctly. As such, this change tries to address this by using prerelease versions that are friendly to Nexus as described [here](https://sonatype.github.io/sonatype-aether/apidocs/org/sonatype/aether/util/version/GenericVersionScheme.html). Specifically, this changes from using `dev` as a prerelease tag to `rc`.

Hopefully, with this change, if the `maven-metadata.xml` gets rebuilt by Nexus, the latest tag will be updated correctly. This [issue](https://github.com/ctapobep/blog/issues/3) provides more details on how and who updates the `maven-metadata.xml` file.

